### PR TITLE
Fix k8sattributesprocessor 

### DIFF
--- a/internal/controller/telemetry/otel_conf_gen.go
+++ b/internal/controller/telemetry/otel_conf_gen.go
@@ -329,27 +329,27 @@ func generateDefaultKubernetesReceiver() map[string]any {
 		{
 			"type": "move",
 			"from": "attributes.container_name",
-			"to":   `attributes["k8s.container.name"]`,
+			"to":   `resource["k8s.container.name"]`,
 		},
 		{
 			"type": "move",
 			"from": "attributes.namespace",
-			"to":   `attributes["k8s.namespace.name"]`,
+			"to":   `resource["k8s.namespace.name"]`,
 		},
 		{
 			"type": "move",
 			"from": "attributes.pod_name",
-			"to":   `attributes["k8s.pod.name"]`,
+			"to":   `resource["k8s.pod.name"]`,
 		},
 		{
 			"type": "move",
 			"from": "attributes.restart_count",
-			"to":   `attributes["k8s.container.restart_count"]`,
+			"to":   `resource["k8s.container.restart_count"]`,
 		},
 		{
 			"type": "move",
 			"from": "attributes.uid",
-			"to":   `attributes["k8s.pod.uid"]`,
+			"to":   `resource["k8s.pod.uid"]`,
 		},
 	}
 


### PR DESCRIPTION
k8s values should be extracted to `resource` or else other k8s related extractions (labels) will silently fail.