### PR TITLE
fix(otel col conf gen): remove regex quotes

### DIFF
--- a/internal/controller/telemetry/otel_conf_gen.go
+++ b/internal/controller/telemetry/otel_conf_gen.go
@@ -386,7 +386,7 @@ func (cfgInput *OtelColConfigInput) generateDefaultKubernetesReceiver() map[stri
 		{
 			"type":   "regex_parser",
 			"id":     "parser-containerd",
-			"regex":  `'^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'`,
+			"regex":  `^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$`,
 			"output": "extract_metadata_from_filepath",
 			"timestamp": map[string]string{
 				"parse_from": "attributes.time",


### PR DESCRIPTION
This fixes the following:

```
{
  "kind": "receiver",
  "name": "filelog/kubernetes",
  "data_type": "logs",
  "operator_id": "parser-containerd",
  "operator_type": "regex_parser",
  "error": "regex pattern does not match",
  "action": "send",
  "entry": {
    "observed_timestamp": "2024-01-23T09:32:57.556310141Z",
    "timestamp": "0001-01-01T00:00:00Z",
    "body": "2024-01-23T09:32:57.5258579Z stdout F 20.112.17.194 - - [23/Jan/2024:09:32:57 +0000] \"GET /blog HTTP/1.1\" 200 15698 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36\" \"-\"",
    "attributes": {
      "log.file.path": "/var/log/pods/example-tenant_log-generator-1706000661-5b8bd5955c-72wgd_040e93b4-9045-4a14-b3b5-a48c326dfcce/log-generator/0.log"
    },
    "severity": 0,
    "scope_name": ""
  }
}
```

[RegExr link](https://regexr.com/7qr9g) 