### PR TITLE
feat(persistence): add file_storage

### DIFF
--- a/api/telemetry/v1alpha1/collector_types.go
+++ b/api/telemetry/v1alpha1/collector_types.go
@@ -22,7 +22,7 @@ import (
 type CollectorSpec struct {
 	TenantSelector   metav1.LabelSelector `json:"tenantSelector,omitempty"`
 	ControlNamespace string               `json:"controlNamespace"`
-	AtomicPersist    bool                 `json:"atomicPersist,omitempty"`
+	Fsync            bool                 `json:"fsync,omitempty"`
 }
 
 // CollectorStatus defines the observed state of Collector

--- a/api/telemetry/v1alpha1/collector_types.go
+++ b/api/telemetry/v1alpha1/collector_types.go
@@ -22,6 +22,7 @@ import (
 type CollectorSpec struct {
 	TenantSelector   metav1.LabelSelector `json:"tenantSelector,omitempty"`
 	ControlNamespace string               `json:"controlNamespace"`
+	AtomicPersist    bool                 `json:"atomicPersist,omitempty"`
 }
 
 // CollectorStatus defines the observed state of Collector

--- a/config/crd/bases/telemetry.kube-logging.dev_collectors.yaml
+++ b/config/crd/bases/telemetry.kube-logging.dev_collectors.yaml
@@ -43,6 +43,8 @@ spec:
           spec:
             description: CollectorSpec defines the desired state of Collector
             properties:
+              atomicPersist:
+                type: boolean
               controlNamespace:
                 type: string
               tenantSelector:

--- a/config/crd/bases/telemetry.kube-logging.dev_collectors.yaml
+++ b/config/crd/bases/telemetry.kube-logging.dev_collectors.yaml
@@ -43,10 +43,10 @@ spec:
           spec:
             description: CollectorSpec defines the desired state of Collector
             properties:
-              atomicPersist:
-                type: boolean
               controlNamespace:
                 type: string
+              fsync:
+                type: boolean
               tenantSelector:
                 description: |-
                   A label selector is a label query over a set of resources. The result of matchLabels and

--- a/docs/examples/simple-demo/one_tenant_two_subscriptions.yaml
+++ b/docs/examples/simple-demo/one_tenant_two_subscriptions.yaml
@@ -16,6 +16,7 @@ metadata:
   name: example-collector
 spec:
   controlNamespace: collector
+  atomicPersist: true
   tenantSelector:
     matchLabels:
       collectorLabel: example-collector

--- a/docs/examples/simple-demo/one_tenant_two_subscriptions.yaml
+++ b/docs/examples/simple-demo/one_tenant_two_subscriptions.yaml
@@ -16,7 +16,7 @@ metadata:
   name: example-collector
 spec:
   controlNamespace: collector
-  atomicPersist: true
+  atomicPersist: false
   tenantSelector:
     matchLabels:
       collectorLabel: example-collector

--- a/docs/examples/simple-demo/one_tenant_two_subscriptions.yaml
+++ b/docs/examples/simple-demo/one_tenant_two_subscriptions.yaml
@@ -16,7 +16,7 @@ metadata:
   name: example-collector
 spec:
   controlNamespace: collector
-  atomicPersist: false
+  fsync: false
   tenantSelector:
     matchLabels:
       collectorLabel: example-collector

--- a/e2e/e2e_test.sh
+++ b/e2e/e2e_test.sh
@@ -11,8 +11,6 @@ create_if_does_not_exist() {
 KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME_E2E:-so-e2e}
 NO_KIND_CLEANUP=${NO_KIND_CLEANUP:-}
 CI_MODE=${CI_MODE:-}
-  # Backup current kubernetes context
-CURRENT_K8S_CTX=$(kubectl config view | grep "current" | cut -f 2 -d : | xargs)
 
 # Prepare env
 kind create cluster --name "${KIND_CLUSTER_NAME}" --wait 5m
@@ -48,23 +46,45 @@ else
 fi
 
 # Create log-generator
-helm install --wait --create-namespace --namespace example-tenant-ns --generate-name oci://ghcr.io/kube-logging/helm-charts/log-generator
+helm install --wait \
+  --create-namespace \
+  --namespace example-tenant-ns \
+  --generate-name oci://ghcr.io/kube-logging/helm-charts/log-generator \
+  --debug \
+  --set app.count=0
 
+LOG_GENERATOR_POD=$(kubectl get pods -A -o custom-columns=':metadata.name' | grep log-generator)
+kubectl port-forward -n example-tenant-ns "pod/${LOG_GENERATOR_POD}" 11000:11000 &
+sleep 5
+JSON_PAYLOAD='{ "type": "web", "format": "apache", "count": 100 }'
+curl --location --request POST '127.0.0.1:11000/loggen' --header 'Content-Type: application/json' --data-raw "${JSON_PAYLOAD}"
 
+# Make sure log generator only generates n log messages
+EXPECTED_NUMBER_OF_LOGS=$(echo "$JSON_PAYLOAD" | jq .count)
+
+EXPECTED_NUMBER_OF_LOGS_CHECKPOINT=15
 # Check for received messages - subscription-sample
 while
-  echo "Checking for subscription-sample-1 in deployments/receiver-collector logs"
-  kubectl logs --namespace example-tenant-ns deployments/receiver-collector | grep -q "subscription-sample-1"
+  echo "Checking for subscription-sample-1 in deployments/receiver-collector logs, expected: ${EXPECTED_NUMBER_OF_LOGS}"
+  NUM_OF_LOGS=$(kubectl logs --namespace example-tenant-ns deployments/receiver-collector | grep -c "subscription-sample-1")
+  echo "Found logs: ${NUM_OF_LOGS}"
+
+  if [[ $NUM_OF_LOGS -eq $EXPECTED_NUMBER_OF_LOGS_CHECKPOINT ]]; then
+    # Kill the telemetry controller to assert persist works
+    TELEMETRY_CONTROLLER_POD=$(kubectl get pods -A -o custom-columns=':metadata.name' | grep  subscription-operator-controller-manager)
+    kubectl delete pod --namespace subscription-operator-system "${TELEMETRY_CONTROLLER_POD}"  
+  fi
+
   
-  [[ $? -ne 0 ]]
+  [[ $NUM_OF_LOGS -ne $EXPECTED_NUMBER_OF_LOGS ]]
 do true; done
 
 # Check for received messages - subscription-sample-2
 while
-  echo "Checking for subscription-sample-2 in deployments/receiver-collector logs"
-  kubectl logs --namespace example-tenant-ns deployments/receiver-collector | grep -q "subscription-sample-2"
+  echo "Checking for subscription-sample-2 in deployments/receiver-collector logs, expected: ${EXPECTED_NUMBER_OF_LOGS}"
+  NUM_OF_LOGS=$(kubectl logs --namespace example-tenant-ns deployments/receiver-collector | grep -c "subscription-sample-2")
 
-  [[ $? -ne 0 ]]
+  [[ $NUM_OF_LOGS -ne $EXPECTED_NUMBER_OF_LOGS ]]
 do true; done
 
 echo "E2E test: PASSED"

--- a/internal/controller/telemetry/collector_controller.go
+++ b/internal/controller/telemetry/collector_controller.go
@@ -220,7 +220,7 @@ func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	mountInitContainer := apiv1.Container{
 		Name:    "persist-mount-fix",
 		Image:   fmt.Sprintf("%s:%s", DefaultMountContainerImage, DefaultMountContainerImageTag),
-		Command: []string{"sh", "-c", "chmod -R 777 " + PersistPath},
+		Command: []string{"sh", "-c", "mkdir -p " + ReceiversPersistPath + "; mkdir -p " + ExportersPersistPath + "; " + "chmod -R 777 " + PersistPath},
 
 		VolumeMounts: []apiv1.VolumeMount{persistVolumeMount},
 	}

--- a/internal/controller/telemetry/otel_col_conf_test_fixtures/complex.yaml
+++ b/internal/controller/telemetry/otel_col_conf_test_fixtures/complex.yaml
@@ -67,12 +67,14 @@ exporters:
         verbosity: detailed
     otlp/collector_otlp-test-output:
         endpoint: receiver-collector.example-tenant-ns.svc.cluster.local:4317
-        sending_queue: "file_storage/exporters"
+        sending_queue: 
+          storage: "file_storage/exporters"
         tls:
             insecure: true
     otlp/collector_otlp-test-output-2:
         endpoint: receiver-collector.example-tenant-ns.svc.cluster.local:4317
-        sending_queue: "file_storage/exporters"
+        sending_queue: 
+          storage: "file_storage/exporters"
         tls:
             insecure: true
 processors:

--- a/internal/controller/telemetry/otel_col_conf_test_fixtures/complex.yaml
+++ b/internal/controller/telemetry/otel_col_conf_test_fixtures/complex.yaml
@@ -1,6 +1,9 @@
 extensions:
-    file_storage/persist:
-        directory: /opt/telemetry-controller/persist
+    file_storage/receiver:
+        directory: /opt/telemetry-controller/persist/receivers
+        fsync: false
+    file_storage/exporters:
+        directory: /opt/telemetry-controller/persist/exporters
         fsync: false
 receivers:
     filelog/kubernetes:
@@ -58,16 +61,18 @@ receivers:
             - from: attributes.uid
               to: resource["k8s.pod.uid"]
               type: move
-        storage: file_storage/persist
+        storage: file_storage/receiver
 exporters:
     logging/debug:
         verbosity: detailed
     otlp/collector_otlp-test-output:
         endpoint: receiver-collector.example-tenant-ns.svc.cluster.local:4317
+        sending_queue: "file_storage/exporters"
         tls:
             insecure: true
     otlp/collector_otlp-test-output-2:
         endpoint: receiver-collector.example-tenant-ns.svc.cluster.local:4317
+        sending_queue: "file_storage/exporters"
         tls:
             insecure: true
 processors:
@@ -116,7 +121,7 @@ connectors:
               pipelines: [logs/tenant_example-tenant]
 service:
     extensions:
-        [file_storage/persist]
+        [file_storage/receiver, file_storage/exporters]
     pipelines:
         logs/all:
             receivers: [filelog/kubernetes]

--- a/internal/controller/telemetry/otel_col_conf_test_fixtures/complex.yaml
+++ b/internal/controller/telemetry/otel_col_conf_test_fixtures/complex.yaml
@@ -1,3 +1,7 @@
+extensions:
+    file_storage/persist:
+        directory: /opt/telemetry-controller/persist
+        fsync: false
 receivers:
     filelog/kubernetes:
         exclude:
@@ -54,7 +58,7 @@ receivers:
             - from: attributes.uid
               to: resource["k8s.pod.uid"]
               type: move
-        start_at: end
+        storage: file_storage/persist
 exporters:
     logging/debug:
         verbosity: detailed
@@ -111,6 +115,8 @@ connectors:
             - statement: 'route() where '
               pipelines: [logs/tenant_example-tenant]
 service:
+    extensions:
+        [file_storage/persist]
     pipelines:
         logs/all:
             receivers: [filelog/kubernetes]

--- a/internal/controller/telemetry/otel_conf_gen.go
+++ b/internal/controller/telemetry/otel_conf_gen.go
@@ -107,7 +107,9 @@ func (cfgInput *OtelColConfigInput) generateOTLPExporters() map[string]any {
 			"tls": map[string]any{
 				"insecure": output.Spec.OTLP.TLSSetting.Insecure,
 			},
-			"sending_queue": ExportersFileStorageName,
+			"sending_queue": map[string]any{
+				"storage": ExportersFileStorageName,
+			},
 		}
 	}
 


### PR DESCRIPTION
# Note

This needs a bit more investigation as it is possible to lose logs even with using `storage`.
For this reason the PR will be a draft first.

```
Found logs: 93
Checking for subscription-sample-1 in deployments/receiver-collector logs, expected: 100
Found logs: 93
Checking for subscription-sample-1 in deployments/receiver-collector logs, expected: 100
Found logs: 93
Checking for subscription-sample-1 in deployments/receiver-collector logs, expected: 100
Found logs: 93
Checking for subscription-sample-1 in deployments/receiver-collector logs, expected: 100
Found logs: 93
Checking for subscription-sample-1 in deployments/receiver-collector logs, expected: 100
E2E test failed
make: *** [Makefile:209: e2e-test] Error 1
```

```
 kubectl logs --namespace example-tenant-ns log-generator-1706798709-5675dcd8fc-9hkqr  | grep  "HTTP/1.1" | wc -l
100
```