### PR TITLE
feat: add tenant-all category to all resources, so we can use kubectl get telemetry-all

### DIFF
--- a/api/telemetry/v1alpha1/collector_types.go
+++ b/api/telemetry/v1alpha1/collector_types.go
@@ -30,9 +30,9 @@ type CollectorStatus struct {
 }
 
 //+kubebuilder:object:root=true
-//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:resource:scope=Cluster,categories=telemetry-all
 //+kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Tenants",type=string,JSONPath=`.status.tenants`
+//+kubebuilder:printcolumn:name="Tenants",type=string,JSONPath=`.status.tenants`
 
 // Collector is the Schema for the collectors API
 type Collector struct {

--- a/api/telemetry/v1alpha1/subscription_types.go
+++ b/api/telemetry/v1alpha1/subscription_types.go
@@ -32,6 +32,7 @@ type SubscriptionStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Tenant",type=string,JSONPath=`.status.tenant`
+//+kubebuilder:resource:categories=telemetry-all
 
 // Subscription is the Schema for the subscriptions API
 type Subscription struct {

--- a/api/telemetry/v1alpha1/tenant_types.go
+++ b/api/telemetry/v1alpha1/tenant_types.go
@@ -32,7 +32,7 @@ type TenantStatus struct {
 }
 
 //+kubebuilder:object:root=true
-//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:resource:scope=Cluster,categories=telemetry-all
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Subscriptions",type=string,JSONPath=`.status.subscriptions`
 //+kubebuilder:printcolumn:name="Logsource namespaces",type=string,JSONPath=`.status.logSourceNamespaces`

--- a/config/crd/bases/telemetry.kube-logging.dev_collectors.yaml
+++ b/config/crd/bases/telemetry.kube-logging.dev_collectors.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: telemetry.kube-logging.dev
   names:
+    categories:
+    - telemetry-all
     kind: Collector
     listKind: CollectorList
     plural: collectors

--- a/config/crd/bases/telemetry.kube-logging.dev_subscriptions.yaml
+++ b/config/crd/bases/telemetry.kube-logging.dev_subscriptions.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: telemetry.kube-logging.dev
   names:
+    categories:
+    - telemetry-all
     kind: Subscription
     listKind: SubscriptionList
     plural: subscriptions

--- a/config/crd/bases/telemetry.kube-logging.dev_tenants.yaml
+++ b/config/crd/bases/telemetry.kube-logging.dev_tenants.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: telemetry.kube-logging.dev
   names:
+    categories:
+    - telemetry-all
     kind: Tenant
     listKind: TenantList
     plural: tenants


### PR DESCRIPTION
Signed-off-by: Kristof Gyuracz <kristof.gyuracz@gmail.com>
