### PR TITLE
feat: add additional traffic metric labels

### DIFF
--- a/internal/controller/telemetry/collector_controller.go
+++ b/internal/controller/telemetry/collector_controller.go
@@ -166,7 +166,7 @@ func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			UpgradeStrategy: "none",
 			Config:          otelConfig,
 			Mode:            otelv1alpha1.ModeDaemonSet,
-			Image:           "ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:0.97.0-axoflow2",
+			Image:           "ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:v0.98.0-axoflow1",
 			ServiceAccount:  saName.Name,
 			VolumeMounts: []corev1.VolumeMount{
 				{

--- a/internal/controller/telemetry/collector_controller.go
+++ b/internal/controller/telemetry/collector_controller.go
@@ -166,7 +166,7 @@ func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			UpgradeStrategy: "none",
 			Config:          otelConfig,
 			Mode:            otelv1alpha1.ModeDaemonSet,
-			Image:           "ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:v0.98.0-axoflow1",
+			Image:           "ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:0.98.0-axoflow-1",
 			ServiceAccount:  saName.Name,
 			VolumeMounts: []corev1.VolumeMount{
 				{

--- a/internal/controller/telemetry/otel_col_conf_test_fixtures/complex.yaml
+++ b/internal/controller/telemetry/otel_col_conf_test_fixtures/complex.yaml
@@ -146,22 +146,30 @@ processors:
 connectors:
     count/output_metrics:
         logs:
-            otelcollector_output_log_count:
+            telemetry_controller_output_log_count:
                 description: The number of logs sent out from each exporter.
                 attributes:
                     - key: tenant
-                      default_value: no_tenant
                     - key: subscription
-                      default_value: no_subscription
                     - key: exporter
-                      default_value: no_exporter
+                resource_attributes:
+                    - key: k8s.namespace.name
+                    - key: k8s.node.name
+                    - key: k8s.container.name
+                    - key: k8s.pod.name
+                    - key: k8s.pod.labels.app.kubernetes.io/name
     count/tenant_metrics:
         logs:
-            otelcollector_tenant_log_count:
+            telemetry_controller_tenant_log_count:
                 description: The number of logs from each tenant pipeline.
                 attributes:
                     - key: tenant
-                      default_value: no_tenant
+                resource_attributes:
+                    - key: k8s.namespace.name
+                    - key: k8s.node.name
+                    - key: k8s.container.name
+                    - key: k8s.pod.name
+                    - key: k8s.pod.labels.app.kubernetes.io/name
     routing/subscription_example-tenant-ns_subscription-example-1_outputs:
         table:
             - statement: route()

--- a/internal/controller/telemetry/otel_conf_gen.go
+++ b/internal/controller/telemetry/otel_conf_gen.go
@@ -75,9 +75,10 @@ type CountConnectorAttributeConfig struct {
 }
 
 type CountConnectorMetricInfo struct {
-	Description string                          `yaml:"description,omitempty"`
-	Conditions  []string                        `yaml:"conditions,omitempty"`
-	Attributes  []CountConnectorAttributeConfig `yaml:"attributes,omitempty"`
+	Description        string                          `yaml:"description,omitempty"`
+	Conditions         []string                        `yaml:"conditions,omitempty"`
+	Attributes         []CountConnectorAttributeConfig `yaml:"attributes,omitempty"`
+	ResourceAttributes []CountConnectorAttributeConfig `yaml:"resource_attributes,omitempty"`
 }
 
 type DeltatoCumulativeConfig struct {
@@ -441,30 +442,61 @@ func generateCountConnectors() map[string]any {
 
 	countConnectors["count/tenant_metrics"] = map[string]any{
 		"logs": map[string]CountConnectorMetricInfo{
-			"otelcollector_tenant_log_count": {
+			"telemetry_controller_tenant_log_count": {
 				Description: "The number of logs from each tenant pipeline.",
 				Attributes: []CountConnectorAttributeConfig{{
-					Key:          "tenant",
-					DefaultValue: "no_tenant",
+					Key: "tenant",
 				}},
+				ResourceAttributes: []CountConnectorAttributeConfig{
+					{
+						Key: "k8s.namespace.name",
+					},
+					{
+						Key: "k8s.node.name",
+					},
+					{
+						Key: "k8s.container.name",
+					},
+					{
+						Key: "k8s.pod.name",
+					},
+					{
+						Key: "k8s.pod.labels.app.kubernetes.io/name",
+					},
+				},
 			},
 		},
 	}
 
 	countConnectors["count/output_metrics"] = map[string]any{
 		"logs": map[string]CountConnectorMetricInfo{
-			"otelcollector_output_log_count": {
+			"telemetry_controller_output_log_count": {
 				Description: "The number of logs sent out from each exporter.",
-				Attributes: []CountConnectorAttributeConfig{{
-					Key:          "tenant",
-					DefaultValue: "no_tenant",
-				}, {
-					Key:          "subscription",
-					DefaultValue: "no_subscription",
-				}, {
-					Key:          "exporter",
-					DefaultValue: "no_exporter",
-				}},
+				Attributes: []CountConnectorAttributeConfig{
+					{
+						Key: "tenant",
+					}, {
+						Key: "subscription",
+					}, {
+						Key: "exporter",
+					}},
+				ResourceAttributes: []CountConnectorAttributeConfig{
+					{
+						Key: "k8s.namespace.name",
+					},
+					{
+						Key: "k8s.node.name",
+					},
+					{
+						Key: "k8s.container.name",
+					},
+					{
+						Key: "k8s.pod.name",
+					},
+					{
+						Key: "k8s.pod.labels.app.kubernetes.io/name",
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
```
# HELP telemetry_controller_output_log_count_total The number of logs sent out from each exporter.
# TYPE telemetry_controller_output_log_count_total counter
telemetry_controller_output_log_count_total{exporter="otlp/collector_otlp-test-output-1",k8s_container_name="log-generator",k8s_namespace_name="example-tenant-ns",k8s_node_name="kind-worker",k8s_pod_labels_app_kubernetes_io_name="log-generator",k8s_pod_name="log-generator-1714635113-596b58d8dc-prnbc",subscription="subscription-sample-1",tenant="example-tenant"} 20
telemetry_controller_output_log_count_total{exporter="otlp/collector_otlp-test-output-2",k8s_container_name="log-generator",k8s_namespace_name="example-tenant-ns",k8s_node_name="kind-worker",k8s_pod_labels_app_kubernetes_io_name="log-generator",k8s_pod_name="log-generator-1714635113-596b58d8dc-prnbc",subscription="subscription-sample-2",tenant="example-tenant"} 20
# HELP telemetry_controller_tenant_log_count_total The number of logs from each tenant pipeline.
# TYPE telemetry_controller_tenant_log_count_total counter
telemetry_controller_tenant_log_count_total{k8s_container_name="log-generator",k8s_namespace_name="example-tenant-ns",k8s_node_name="kind-worker",k8s_pod_labels_app_kubernetes_io_name="log-generator",k8s_pod_name="log-generator-1714635113-596b58d8dc-prnbc",tenant="example-tenant"} 20
```