### PR TITLE
fix: install tagged image on kustomize install instead of latest

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/kube-logging/telemetry-controller
-  newTag: latest
+  newTag: 0.0.4


### PR DESCRIPTION
Signed-off-by: Kristof Gyuracz <kristof.gyuracz@axoflow.com>
