### PR TITLE
fix: stabilize operator behaviour

### DIFF
--- a/api/telemetry/v1alpha1/collector_types.go
+++ b/api/telemetry/v1alpha1/collector_types.go
@@ -80,12 +80,14 @@ func (c CollectorSpec) GetMemoryLimit() *resource.Quantity {
 
 // CollectorStatus defines the observed state of Collector
 type CollectorStatus struct {
+	State   State    `json:"state,omitempty"`
 	Tenants []string `json:"tenants,omitempty"`
 }
 
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:scope=Cluster,categories=telemetry-all
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
 //+kubebuilder:printcolumn:name="Tenants",type=string,JSONPath=`.status.tenants`
 
 // Collector is the Schema for the collectors API

--- a/api/telemetry/v1alpha1/collector_types.go
+++ b/api/telemetry/v1alpha1/collector_types.go
@@ -80,15 +80,15 @@ func (c CollectorSpec) GetMemoryLimit() *resource.Quantity {
 
 // CollectorStatus defines the observed state of Collector
 type CollectorStatus struct {
-	State   State    `json:"state,omitempty"`
 	Tenants []string `json:"tenants,omitempty"`
+	State   State    `json:"state,omitempty"`
 }
 
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:scope=Cluster,categories=telemetry-all
 //+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
 //+kubebuilder:printcolumn:name="Tenants",type=string,JSONPath=`.status.tenants`
+//+kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
 
 // Collector is the Schema for the collectors API
 type Collector struct {

--- a/charts/telemetry-controller/crds/telemetry.kube-logging.dev_collectors.yaml
+++ b/charts/telemetry-controller/crds/telemetry.kube-logging.dev_collectors.yaml
@@ -17,6 +17,9 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.state
+      name: State
+      type: string
     - jsonPath: .status.tenants
       name: Tenants
       type: string
@@ -8071,6 +8074,8 @@ spec:
           status:
             description: CollectorStatus defines the observed state of Collector
             properties:
+              state:
+                type: string
               tenants:
                 items:
                   type: string

--- a/charts/telemetry-controller/crds/telemetry.kube-logging.dev_collectors.yaml
+++ b/charts/telemetry-controller/crds/telemetry.kube-logging.dev_collectors.yaml
@@ -17,11 +17,11 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.state
-      name: State
-      type: string
     - jsonPath: .status.tenants
       name: Tenants
+      type: string
+    - jsonPath: .status.state
+      name: State
       type: string
     name: v1alpha1
     schema:

--- a/config/crd/bases/telemetry.kube-logging.dev_collectors.yaml
+++ b/config/crd/bases/telemetry.kube-logging.dev_collectors.yaml
@@ -17,6 +17,9 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.state
+      name: State
+      type: string
     - jsonPath: .status.tenants
       name: Tenants
       type: string
@@ -8071,6 +8074,8 @@ spec:
           status:
             description: CollectorStatus defines the observed state of Collector
             properties:
+              state:
+                type: string
               tenants:
                 items:
                   type: string

--- a/config/crd/bases/telemetry.kube-logging.dev_collectors.yaml
+++ b/config/crd/bases/telemetry.kube-logging.dev_collectors.yaml
@@ -17,11 +17,11 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.state
-      name: State
-      type: string
     - jsonPath: .status.tenants
       name: Tenants
+      type: string
+    - jsonPath: .status.state
+      name: State
       type: string
     name: v1alpha1
     schema:

--- a/docs/examples/tenant-to-tenant-routing/pipeline.yaml
+++ b/docs/examples/tenant-to-tenant-routing/pipeline.yaml
@@ -24,35 +24,6 @@ spec:
   logSourceNamespaceSelectors:
     - matchLabels:
         tenant: shared
-  subscriptionNamespaceSelectors:
-    - matchLabels:
-        tenant: shared
----
-apiVersion: telemetry.kube-logging.dev/v1alpha1
-kind: Subscription
-metadata:
-  name: shared
-  namespace: shared
-spec:
-  condition: "true"
-  outputs:
-    - name: openobserve-shared
-      namespace: shared
----
-apiVersion: telemetry.kube-logging.dev/v1alpha1
-kind: Output
-metadata:
-  name: openobserve-shared
-  namespace: shared
-spec:
-  otlp:
-    endpoint: openobserve-otlp-grpc.openobserve.svc.cluster.local:5081
-    headers:
-      Authorization: "Basic <TOKEN>"
-      organization: default
-      stream-name: shared
-    tls:
-      insecure: true
 ---
 # A tenant that consumes logs from the shared tenant using a bridge
 apiVersion: telemetry.kube-logging.dev/v1alpha1
@@ -62,9 +33,6 @@ metadata:
     collector: cluster
   name: database
 spec:
-  logSourceNamespaceSelectors:
-    - matchLabels:
-        tenant: database
   subscriptionNamespaceSelectors:
     - matchLabels:
         tenant: database
@@ -112,9 +80,6 @@ metadata:
     collector: cluster
   name: web
 spec:
-  logSourceNamespaceSelectors:
-    - matchLabels:
-        tenant: web
   subscriptionNamespaceSelectors:
     - matchLabels:
         tenant: web

--- a/e2e/testdata/tenants_with_bridges/tenants_with_bridges.yaml
+++ b/e2e/testdata/tenants_with_bridges/tenants_with_bridges.yaml
@@ -50,31 +50,6 @@ spec:
   logSourceNamespaceSelectors:
     - matchLabels:
         tenant: shared
-  subscriptionNamespaceSelectors:
-    - matchLabels:
-        tenant: shared
----
-apiVersion: telemetry.kube-logging.dev/v1alpha1
-kind: Subscription
-metadata:
-  name: shared
-  namespace: shared
-spec:
-  condition: "true"
-  outputs:
-    - name: otlp-test-output-shared
-      namespace: collector
----
-apiVersion: telemetry.kube-logging.dev/v1alpha1
-kind: Output
-metadata:
-  name: otlp-test-output-shared
-  namespace: collector
-spec:
-  otlp:
-    endpoint: receiver-collector.telemetry-controller-system.svc.cluster.local:4317
-    tls:
-      insecure: true
 ---
 # A tenant that consumes logs from the shared tenant using a bridge
 apiVersion: telemetry.kube-logging.dev/v1alpha1
@@ -84,9 +59,6 @@ metadata:
     collector: cluster
   name: database
 spec:
-  logSourceNamespaceSelectors:
-    - matchLabels:
-        tenant: database
   subscriptionNamespaceSelectors:
     - matchLabels:
         tenant: database
@@ -130,9 +102,6 @@ metadata:
     collector: cluster
   name: web
 spec:
-  logSourceNamespaceSelectors:
-    - matchLabels:
-        tenant: web
   subscriptionNamespaceSelectors:
     - matchLabels:
         tenant: web

--- a/go.mod
+++ b/go.mod
@@ -25,9 +25,11 @@ require (
 	k8s.io/client-go v0.30.2
 	sigs.k8s.io/controller-runtime v0.18.4
 	sigs.k8s.io/yaml v1.4.0
+	github.com/hashicorp/go-multierror v1.1.1
 )
 
 require (
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/briandowns/spinner v1.23.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,11 @@ github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 h1:k7nVchz72niMH6YLQN
 github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
+github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/iancoleman/orderedmap v0.3.0 h1:5cbR2grmZR/DiVt+VJopEhtVs9YGInGIxAoMJn+Ichc=
 github.com/iancoleman/orderedmap v0.3.0/go.mod h1:XuLcCUkdL5owUCQeF2Ue9uuw1EptkJDkXXS7VoV7XGE=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=

--- a/internal/controller/telemetry/collector_controller.go
+++ b/internal/controller/telemetry/collector_controller.go
@@ -199,6 +199,14 @@ func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
+	// NOTE: This might be revised or removed in the future, but good enough for now to avoid
+	// deploying the collector that would immediately error due to configuration errors.
+	// Might also be a good place to add a validation webhook to validate the collector spec
+	if err := otelConfigInput.ValidateConfig(); err != nil {
+		logger.Error(errors.WithStack(err), "failed validating otel config input")
+		return ctrl.Result{}, err
+	}
+
 	otelConfig := otelConfigInput.AssembleConfig(ctx)
 
 	saName, err := r.reconcileRBAC(ctx, collector)

--- a/internal/controller/telemetry/collector_controller.go
+++ b/internal/controller/telemetry/collector_controller.go
@@ -203,6 +203,7 @@ func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// deploying the collector that would immediately error due to configuration errors.
 	// Might also be a good place to add a validation webhook to validate the collector spec
 	if err := otelConfigInput.ValidateConfig(); err != nil {
+		collector.Status.State = v1alpha1.StateFailed
 		logger.Error(errors.WithStack(err), "failed validating otel config input")
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
## Fixes the following issues:

- Previously the `collector` failed with a conflict error, now we re-queue that reconcile attempt, I have tracked and confirmed that eventually the conflicting reconcile succeeds.
- Added a minimal config-check, that we might get rid of later, but it's a good-enough start IMO, partially fixes: #22
**NOTE: I will do a follow-up PR and come up with a better config-check**
- Noticed that we could panic if a `Bridge` had either no `source` or `target tenant`... Fixed.
- #63
- Upon introducing `Bridges`, we opened up the possibility to have a Tenant with either no `subs` or `logsource-ns's`, but It wasn't possible before.

### Topology differences:

[BEFORE](https://www.otelbin.io/#config=connectors%3A*N__count%2Foutput*_metrics%3A*N____logs%3A*N______telemetry*_controller*_output*_log*_count%3A*N________attributes%3A*N__________-_key%3A_tenant*N__________-_key%3A_subscription*N__________-_key%3A_exporter*N________description%3A_The_number_of_logs_sent_out_from_each_exporter.*N________resource*_attributes%3A*N__________-_key%3A_k8s.namespace.name*N__________-_key%3A_k8s.node.name*N__________-_key%3A_k8s.container.name*N__________-_key%3A_k8s.pod.name*N__________-_key%3A_k8s.pod.labels.app.kubernetes.io%2Fname*N__________-_key%3A_k8s.pod.labels.app*N__count%2Ftenant*_metrics%3A*N____logs%3A*N______telemetry*_controller*_tenant*_log*_count%3A*N________attributes%3A*N__________-_key%3A_tenant*N________description%3A_The_number_of_logs_from_each_tenant_pipeline.*N________resource*_attributes%3A*N__________-_key%3A_k8s.namespace.name*N__________-_key%3A_k8s.node.name*N__________-_key%3A_k8s.container.name*N__________-_key%3A_k8s.pod.name*N__________-_key%3A_k8s.pod.labels.app.kubernetes.io%2Fname*N__________-_key%3A_k8s.pod.labels.app*N__routing%2Fbridge*_shared-database%3A*N____table%3A*N______-_pipelines%3A*N__________-_logs%2Ftenant*_database*N________statement%3A_route*C*D_where_attributes%5B%22parsed%22%5D%5B%22method%22%5D_*E*E_%22GET%22*N__routing%2Fbridge*_shared-web%3A*N____table%3A*N______-_pipelines%3A*N__________-_logs%2Ftenant*_web*N________statement%3A_route*C*D_where_attributes%5B%22parsed%22%5D%5B%22method%22%5D_*E*E_%22PUT%22*N__routing%2Fsubscription*_database*_database*_outputs%3A*N____table%3A*N______-_pipelines%3A*N__________-_logs%2Foutput*_database*_database*_database*_openobserve-database*N________statement%3A_route*C*D*N__routing%2Fsubscription*_shared*_shared*_outputs%3A*N____table%3A*N______-_pipelines%3A*N__________-_logs%2Foutput*_shared*_shared*_shared*_openobserve-shared*N________statement%3A_route*C*D*N__routing%2Fsubscription*_web*_web*_outputs%3A*N____table%3A*N______-_pipelines%3A*N__________-_logs%2Foutput*_web*_web*_web*_openobserve-web*N________statement%3A_route*C*D*N__routing%2Ftenant*_database*_subscriptions%3A*N____table%3A*N______-_pipelines%3A*N__________-_logs%2Ftenant*_database*_subscription*_database*_database*N________statement%3A_route*C*D*N__routing%2Ftenant*_shared*_subscriptions%3A*N____table%3A*N______-_pipelines%3A*N__________-_logs%2Ftenant*_shared*_subscription*_shared*_shared*N________statement%3A_route*C*D*N__routing%2Ftenant*_web*_subscriptions%3A*N____table%3A*N______-_pipelines%3A*N__________-_logs%2Ftenant*_web*_subscription*_web*_web*N________statement%3A_route*C*D*Nexporters%3A*N__logging%2Fdebug%3A*N____verbosity%3A_detailed*N__otlp%2Fdatabase*_openobserve-database%3A*N____endpoint%3A_openobserve-otlp-grpc.openobserve.svc.cluster.local%3A5081*N____headers%3A*N______Authorization%3A_Basic_*LTOKEN*G*N______organization%3A_default*N______stream-name%3A_db*N____retry*_on*_failure%3A_%7B%7D*N____sending*_queue%3A_%7B%7D*N____tls%3A*N______insecure%3A_true*N__otlp%2Fshared*_openobserve-shared%3A*N____endpoint%3A_openobserve-otlp-grpc.openobserve.svc.cluster.local%3A5081*N____headers%3A*N______Authorization%3A_Basic_*LTOKEN*G*N______organization%3A_default*N______stream-name%3A_shared*N____retry*_on*_failure%3A_%7B%7D*N____sending*_queue%3A_%7B%7D*N____tls%3A*N______insecure%3A_true*N__otlp%2Fweb*_openobserve-web%3A*N____endpoint%3A_openobserve-otlp-grpc.openobserve.svc.cluster.local%3A5081*N____headers%3A*N______Authorization%3A_Basic_*LTOKEN*G*N______organization%3A_default*N______stream-name%3A_web*N____retry*_on*_failure%3A_%7B%7D*N____sending*_queue%3A_%7B%7D*N____tls%3A*N______insecure%3A_true*N__prometheus%2Fmessage*_metrics*_exporter%3A*N____endpoint%3A_0.0.0.0%3A9999*N____resource*_to*_telemetry*_conversion%3A_%7B%7D*Nextensions%3A_%7B%7D*Nprocessors%3A*N__attributes%2Fexporter*_name*_openobserve-database%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_exporter*N________value%3A_otlp%2Fdatabase*_openobserve-database*N__attributes%2Fexporter*_name*_openobserve-shared%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_exporter*N________value%3A_otlp%2Fshared*_openobserve-shared*N__attributes%2Fexporter*_name*_openobserve-web%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_exporter*N________value%3A_otlp%2Fweb*_openobserve-web*N__attributes%2Fmetricattributes%3A*N____actions%3A*N______-_action%3A_insert*N________from*_attribute%3A_k8s.pod.labels.app*N________key%3A_app*N______-_action%3A_insert*N________from*_attribute%3A_k8s.node.name*N________key%3A_host*N______-_action%3A_insert*N________from*_attribute%3A_k8s.namespace.name*N________key%3A_namespace*N______-_action%3A_insert*N________from*_attribute%3A_k8s.container.name*N________key%3A_container*N______-_action%3A_insert*N________from*_attribute%3A_k8s.pod.name*N________key%3A_pod*N__attributes%2Fsubscription*_database%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_subscription*N________value%3A_database*N__attributes%2Fsubscription*_shared%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_subscription*N________value%3A_shared*N__attributes%2Fsubscription*_web%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_subscription*N________value%3A_web*N__attributes%2Ftenant*_database%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_tenant*N________value%3A_database*N__attributes%2Ftenant*_shared%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_tenant*N________value%3A_shared*N__attributes%2Ftenant*_web%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_tenant*N________value%3A_web*N__deltatocumulative%3A_%7B%7D*N__k8sattributes%3A*N____auth*_type%3A_serviceAccount*N____extract%3A*N______labels%3A*N________-_from%3A_pod*N__________key*_regex%3A_.***N__________tag*_name%3A_all*_labels*N______metadata%3A*N________-_k8s.pod.name*N________-_k8s.pod.uid*N________-_k8s.deployment.name*N________-_k8s.namespace.name*N________-_k8s.node.name*N________-_k8s.pod.start*_time*N____passthrough%3A_false*N____pod*_association%3A*N______-_sources%3A*N__________-_from%3A_resource*_attribute*N____________name%3A_k8s.namespace.name*N__________-_from%3A_resource*_attribute*N____________name%3A_k8s.pod.name*N__memory*_limiter%3A*N____check*_interval%3A_1s*N____limit*_percentage%3A_75*N____spike*_limit*_mib%3A_25*N__transform%2Fparse-nginx%3A*N____log*_statements%3A*N______-_conditions%3A_null*N________context%3A_log*N________statements%3A*N__________-_set*Cresource.attributes%5B%22parsed%22%5D%2C_ExtractPatterns*Cbody%2C_%22*C*QP*Lmethod*G*CGET%7CPUT*D*D%22*D*D*Nreceivers%3A*N__filelog%2Fdatabase%3A*N____exclude%3A*N______-_%2Fvar%2Flog%2Fpods%2F**%2Fotc-container%2F**.log*N____include%3A*N______-_%2Fvar%2Flog%2Fpods%2Fdatabase*_**%2F**%2F**.log*N____include*_file*_name%3A_false*N____include*_file*_path%3A_true*N____operators%3A*N______-_id%3A_get-format*N________routes%3A*N__________-_expr%3A_body_matches_%22%5E*B*B%7B%22*N____________output%3A_parser-docker*N__________-_expr%3A_body_matches_%22%5E%5B%5E_Z%5D*PZ%22*N____________output%3A_parser-containerd*N________type%3A_router*N______-_id%3A_parser-containerd*N________output%3A_extract*_metadata*_from*_filepath*N________regex%3A_%5E*C*QP*Ltime*G%5B%5E_%5EZ%5D*PZ*D_*C*QP*Lstream*Gstdout%7Cstderr*D_*C*QP*Llogtag*G%5B%5E_%5D***D_*Q*C*QP*Llog*G.***D*S*N________timestamp%3A*N__________layout%3A_*%22*.Y-*.m-*.dT*.H%3A*.M%3A*.S.*.LZ*%22*N__________parse*_from%3A_attributes.time*N________type%3A_regex*_parser*N______-_id%3A_parser-docker*N________output%3A_extract*_metadata*_from*_filepath*N________timestamp%3A*N__________layout%3A_*%22*.Y-*.m-*.dT*.H%3A*.M%3A*.S.*.LZ*%22*N__________parse*_from%3A_attributes.time*N________type%3A_json*_parser*N______-_cache%3A*N__________size%3A_128*N________id%3A_extract*_metadata*_from*_filepath*N________parse*_from%3A_attributes%5B%22log.file.path%22%5D*N________regex%3A_%5E.***B%2F*C*QP*Lnamespace*G%5B%5E*_%5D*P*D*_*C*QP*Lpod*_name*G%5B%5E*_%5D*P*D*_*C*QP*Luid*G%5Ba-f0-9-%5D*P*D*B%2F*C*QP*Lcontainer*_name*G%5B%5E*B%2F%5D*P*D*B%2F*C*QP*Lrestart*_count*G*Bd*P*D*B.log*S*N________type%3A_regex*_parser*N______-_from%3A_attributes.log*N________to%3A_body*N________type%3A_move*N______-_from%3A_attributes.stream*N________to%3A_attributes%5B%22log.iostream%22%5D*N________type%3A_move*N______-_from%3A_attributes.container*_name*N________to%3A_resource%5B%22k8s.container.name%22%5D*N________type%3A_move*N______-_from%3A_attributes.namespace*N________to%3A_resource%5B%22k8s.namespace.name%22%5D*N________type%3A_move*N______-_from%3A_attributes.pod*_name*N________to%3A_resource%5B%22k8s.pod.name%22%5D*N________type%3A_move*N______-_from%3A_attributes.restart*_count*N________to%3A_resource%5B%22k8s.container.restart*_count%22%5D*N________type%3A_move*N______-_from%3A_attributes.uid*N________to%3A_resource%5B%22k8s.pod.uid%22%5D*N________type%3A_move*N____retry*_on*_failure%3A*N______enabled%3A_true*N______max*_elapsed*_time%3A_0*N____start*_at%3A_end*N__filelog%2Fshared%3A*N____exclude%3A*N______-_%2Fvar%2Flog%2Fpods%2F**%2Fotc-container%2F**.log*N____include%3A*N______-_%2Fvar%2Flog%2Fpods%2Fshared*_**%2F**%2F**.log*N____include*_file*_name%3A_false*N____include*_file*_path%3A_true*N____operators%3A*N______-_id%3A_get-format*N________routes%3A*N__________-_expr%3A_body_matches_%22%5E*B*B%7B%22*N____________output%3A_parser-docker*N__________-_expr%3A_body_matches_%22%5E%5B%5E_Z%5D*PZ%22*N____________output%3A_parser-containerd*N________type%3A_router*N______-_id%3A_parser-containerd*N________output%3A_extract*_metadata*_from*_filepath*N________regex%3A_%5E*C*QP*Ltime*G%5B%5E_%5EZ%5D*PZ*D_*C*QP*Lstream*Gstdout%7Cstderr*D_*C*QP*Llogtag*G%5B%5E_%5D***D_*Q*C*QP*Llog*G.***D*S*N________timestamp%3A*N__________layout%3A_*%22*.Y-*.m-*.dT*.H%3A*.M%3A*.S.*.LZ*%22*N__________parse*_from%3A_attributes.time*N________type%3A_regex*_parser*N______-_id%3A_parser-docker*N________output%3A_extract*_metadata*_from*_filepath*N________timestamp%3A*N__________layout%3A_*%22*.Y-*.m-*.dT*.H%3A*.M%3A*.S.*.LZ*%22*N__________parse*_from%3A_attributes.time*N________type%3A_json*_parser*N______-_cache%3A*N__________size%3A_128*N________id%3A_extract*_metadata*_from*_filepath*N________parse*_from%3A_attributes%5B%22log.file.path%22%5D*N________regex%3A_%5E.***B%2F*C*QP*Lnamespace*G%5B%5E*_%5D*P*D*_*C*QP*Lpod*_name*G%5B%5E*_%5D*P*D*_*C*QP*Luid*G%5Ba-f0-9-%5D*P*D*B%2F*C*QP*Lcontainer*_name*G%5B%5E*B%2F%5D*P*D*B%2F*C*QP*Lrestart*_count*G*Bd*P*D*B.log*S*N________type%3A_regex*_parser*N______-_from%3A_attributes.log*N________to%3A_body*N________type%3A_move*N______-_from%3A_attributes.stream*N________to%3A_attributes%5B%22log.iostream%22%5D*N________type%3A_move*N______-_from%3A_attributes.container*_name*N________to%3A_resource%5B%22k8s.container.name%22%5D*N________type%3A_move*N______-_from%3A_attributes.namespace*N________to%3A_resource%5B%22k8s.namespace.name%22%5D*N________type%3A_move*N______-_from%3A_attributes.pod*_name*N________to%3A_resource%5B%22k8s.pod.name%22%5D*N________type%3A_move*N______-_from%3A_attributes.restart*_count*N________to%3A_resource%5B%22k8s.container.restart*_count%22%5D*N________type%3A_move*N______-_from%3A_attributes.uid*N________to%3A_resource%5B%22k8s.pod.uid%22%5D*N________type%3A_move*N____retry*_on*_failure%3A*N______enabled%3A_true*N______max*_elapsed*_time%3A_0*N____start*_at%3A_end*N__filelog%2Fweb%3A*N____exclude%3A*N______-_%2Fvar%2Flog%2Fpods%2F**%2Fotc-container%2F**.log*N____include%3A*N______-_%2Fvar%2Flog%2Fpods%2Fweb*_**%2F**%2F**.log*N____include*_file*_name%3A_false*N____include*_file*_path%3A_true*N____operators%3A*N______-_id%3A_get-format*N________routes%3A*N__________-_expr%3A_body_matches_%22%5E*B*B%7B%22*N____________output%3A_parser-docker*N__________-_expr%3A_body_matches_%22%5E%5B%5E_Z%5D*PZ%22*N____________output%3A_parser-containerd*N________type%3A_router*N______-_id%3A_parser-containerd*N________output%3A_extract*_metadata*_from*_filepath*N________regex%3A_%5E*C*QP*Ltime*G%5B%5E_%5EZ%5D*PZ*D_*C*QP*Lstream*Gstdout%7Cstderr*D_*C*QP*Llogtag*G%5B%5E_%5D***D_*Q*C*QP*Llog*G.***D*S*N________timestamp%3A*N__________layout%3A_*%22*.Y-*.m-*.dT*.H%3A*.M%3A*.S.*.LZ*%22*N__________parse*_from%3A_attributes.time*N________type%3A_regex*_parser*N______-_id%3A_parser-docker*N________output%3A_extract*_metadata*_from*_filepath*N________timestamp%3A*N__________layout%3A_*%22*.Y-*.m-*.dT*.H%3A*.M%3A*.S.*.LZ*%22*N__________parse*_from%3A_attributes.time*N________type%3A_json*_parser*N______-_cache%3A*N__________size%3A_128*N________id%3A_extract*_metadata*_from*_filepath*N________parse*_from%3A_attributes%5B%22log.file.path%22%5D*N________regex%3A_%5E.***B%2F*C*QP*Lnamespace*G%5B%5E*_%5D*P*D*_*C*QP*Lpod*_name*G%5B%5E*_%5D*P*D*_*C*QP*Luid*G%5Ba-f0-9-%5D*P*D*B%2F*C*QP*Lcontainer*_name*G%5B%5E*B%2F%5D*P*D*B%2F*C*QP*Lrestart*_count*G*Bd*P*D*B.log*S*N________type%3A_regex*_parser*N______-_from%3A_attributes.log*N________to%3A_body*N________type%3A_move*N______-_from%3A_attributes.stream*N________to%3A_attributes%5B%22log.iostream%22%5D*N________type%3A_move*N______-_from%3A_attributes.container*_name*N________to%3A_resource%5B%22k8s.container.name%22%5D*N________type%3A_move*N______-_from%3A_attributes.namespace*N________to%3A_resource%5B%22k8s.namespace.name%22%5D*N________type%3A_move*N______-_from%3A_attributes.pod*_name*N________to%3A_resource%5B%22k8s.pod.name%22%5D*N________type%3A_move*N______-_from%3A_attributes.restart*_count*N________to%3A_resource%5B%22k8s.container.restart*_count%22%5D*N________type%3A_move*N______-_from%3A_attributes.uid*N________to%3A_resource%5B%22k8s.pod.uid%22%5D*N________type%3A_move*N____retry*_on*_failure%3A*N______enabled%3A_true*N______max*_elapsed*_time%3A_0*N____start*_at%3A_end*Nservice%3A*N__extensions%3A_%5B%5D*N__pipelines%3A*N____logs%2Foutput*_database*_database*_database*_openobserve-database%3A*N______exporters%3A*N________-_otlp%2Fdatabase*_openobserve-database*N________-_count%2Foutput*_metrics*N______processors%3A*N________-_memory*_limiter*N________-_attributes%2Fexporter*_name*_openobserve-database*N______receivers%3A*N________-_routing%2Fsubscription*_database*_database*_outputs*N____logs%2Foutput*_shared*_shared*_shared*_openobserve-shared%3A*N______exporters%3A*N________-_otlp%2Fshared*_openobserve-shared*N________-_count%2Foutput*_metrics*N______processors%3A*N________-_memory*_limiter*N________-_attributes%2Fexporter*_name*_openobserve-shared*N______receivers%3A*N________-_routing%2Fsubscription*_shared*_shared*_outputs*N____logs%2Foutput*_web*_web*_web*_openobserve-web%3A*N______exporters%3A*N________-_otlp%2Fweb*_openobserve-web*N________-_count%2Foutput*_metrics*N______processors%3A*N________-_memory*_limiter*N________-_attributes%2Fexporter*_name*_openobserve-web*N______receivers%3A*N________-_routing%2Fsubscription*_web*_web*_outputs*N____logs%2Ftenant*_database%3A*N______exporters%3A*N________-_routing%2Ftenant*_database*_subscriptions*N________-_count%2Ftenant*_metrics*N______processors%3A*N________-_memory*_limiter*N________-_k8sattributes*N________-_attributes%2Ftenant*_database*N______receivers%3A*N________-_filelog%2Fdatabase*N________-_routing%2Fbridge*_shared-database*N____logs%2Ftenant*_database*_subscription*_database*_database%3A*N______exporters%3A*N________-_routing%2Fsubscription*_database*_database*_outputs*N______processors%3A*N________-_memory*_limiter*N________-_attributes%2Fsubscription*_database*N______receivers%3A*N________-_routing%2Ftenant*_database*_subscriptions*N____logs%2Ftenant*_shared%3A*N______exporters%3A*N________-_routing%2Ftenant*_shared*_subscriptions*N________-_count%2Ftenant*_metrics*N________-_routing%2Fbridge*_shared-database*N________-_routing%2Fbridge*_shared-web*N______processors%3A*N________-_memory*_limiter*N________-_k8sattributes*N________-_attributes%2Ftenant*_shared*N________-_transform%2Fparse-nginx*N______receivers%3A*N________-_filelog%2Fshared*N____logs%2Ftenant*_shared*_subscription*_shared*_shared%3A*N______exporters%3A*N________-_routing%2Fsubscription*_shared*_shared*_outputs*N______processors%3A*N________-_memory*_limiter*N________-_attributes%2Fsubscription*_shared*N______receivers%3A*N________-_routing%2Ftenant*_shared*_subscriptions*N____logs%2Ftenant*_web%3A*N______exporters%3A*N________-_routing%2Ftenant*_web*_subscriptions*N________-_count%2Ftenant*_metrics*N______processors%3A*N________-_memory*_limiter*N________-_k8sattributes*N________-_attributes%2Ftenant*_web*N______receivers%3A*N________-_filelog%2Fweb*N________-_routing%2Fbridge*_shared-web*N____logs%2Ftenant*_web*_subscription*_web*_web%3A*N______exporters%3A*N________-_routing%2Fsubscription*_web*_web*_outputs*N______processors%3A*N________-_memory*_limiter*N________-_attributes%2Fsubscription*_web*N______receivers%3A*N________-_routing%2Ftenant*_web*_subscriptions*N____metrics%2Foutput%3A*N______exporters%3A*N________-_prometheus%2Fmessage*_metrics*_exporter*N______processors%3A*N________-_memory*_limiter*N________-_deltatocumulative*N________-_attributes%2Fmetricattributes*N______receivers%3A*N________-_count%2Foutput*_metrics*N____metrics%2Ftenant%3A*N______exporters%3A*N________-_prometheus%2Fmessage*_metrics*_exporter*N______processors%3A*N________-_memory*_limiter*N________-_deltatocumulative*N________-_attributes%2Fmetricattributes*N______receivers%3A*N________-_count%2Ftenant*_metrics*N__telemetry%3A*N____metrics%3A*N______level%3A_detailed*N%7E)
[AFTER](https://www.otelbin.io/#config=connectors%3A*N__count%2Foutput*_metrics%3A*N____logs%3A*N______telemetry*_controller*_output*_log*_count%3A*N________attributes%3A*N__________-_key%3A_tenant*N__________-_key%3A_subscription*N__________-_key%3A_exporter*N________description%3A_The_number_of_logs_sent_out_from_each_exporter.*N________resource*_attributes%3A*N__________-_key%3A_k8s.namespace.name*N__________-_key%3A_k8s.node.name*N__________-_key%3A_k8s.container.name*N__________-_key%3A_k8s.pod.name*N__________-_key%3A_k8s.pod.labels.app.kubernetes.io%2Fname*N__________-_key%3A_k8s.pod.labels.app*N__count%2Ftenant*_metrics%3A*N____logs%3A*N______telemetry*_controller*_tenant*_log*_count%3A*N________attributes%3A*N__________-_key%3A_tenant*N________description%3A_The_number_of_logs_from_each_tenant_pipeline.*N________resource*_attributes%3A*N__________-_key%3A_k8s.namespace.name*N__________-_key%3A_k8s.node.name*N__________-_key%3A_k8s.container.name*N__________-_key%3A_k8s.pod.name*N__________-_key%3A_k8s.pod.labels.app.kubernetes.io%2Fname*N__________-_key%3A_k8s.pod.labels.app*N__routing%2Fbridge*_shared-database%3A*N____table%3A*N______-_condition%3A_attributes%5B%22parsed%22%5D%5B%22method%22%5D_*E*E_%22GET%22*N________pipelines%3A*N__________-_logs%2Ftenant*_database*N__routing%2Fbridge*_shared-web%3A*N____table%3A*N______-_condition%3A_attributes%5B%22parsed%22%5D%5B%22method%22%5D_*E*E_%22PUT%22*N________pipelines%3A*N__________-_logs%2Ftenant*_web*N__routing%2Fsubscription*_database*_database*_outputs%3A*N____table%3A*N______-_condition%3A_%22true%22*N________pipelines%3A*N__________-_logs%2Foutput*_database*_database*_database*_openobserve-database*N__routing%2Fsubscription*_web*_web*_outputs%3A*N____table%3A*N______-_condition%3A_%22true%22*N________pipelines%3A*N__________-_logs%2Foutput*_web*_web*_web*_openobserve-web*N__routing%2Ftenant*_database*_subscriptions%3A*N____table%3A*N______-_condition%3A_%22true%22*N________pipelines%3A*N__________-_logs%2Ftenant*_database*_subscription*_database*_database*N__routing%2Ftenant*_web*_subscriptions%3A*N____table%3A*N______-_condition%3A_%22true%22*N________pipelines%3A*N__________-_logs%2Ftenant*_web*_subscription*_web*_web*Nexporters%3A*N__debug%3A*N____verbosity%3A_detailed*N__otlp%2Fdatabase*_openobserve-database%3A*N____endpoint%3A_openobserve-otlp-grpc.openobserve.svc.cluster.local%3A5081*N____headers%3A*N______Authorization%3A_Basic_*LTOKEN*G*N______organization%3A_default*N______stream-name%3A_db*N____tls%3A*N______insecure%3A_true*N__otlp%2Fweb*_openobserve-web%3A*N____endpoint%3A_openobserve-otlp-grpc.openobserve.svc.cluster.local%3A5081*N____headers%3A*N______Authorization%3A_Basic_*LTOKEN*G*N______organization%3A_default*N______stream-name%3A_web*N____tls%3A*N______insecure%3A_true*N__prometheus%2Fmessage*_metrics*_exporter%3A*N____endpoint%3A_0.0.0.0%3A9999*N____resource*_to*_telemetry*_conversion%3A_%7B%7D*Nextensions%3A_%7B%7D*Nprocessors%3A*N__attributes%2Fexporter*_name*_openobserve-database%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_exporter*N________value%3A_otlp%2Fdatabase*_openobserve-database*N__attributes%2Fexporter*_name*_openobserve-web%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_exporter*N________value%3A_otlp%2Fweb*_openobserve-web*N__attributes%2Fmetricattributes%3A*N____actions%3A*N______-_action%3A_insert*N________from*_attribute%3A_k8s.pod.labels.app*N________key%3A_app*N______-_action%3A_insert*N________from*_attribute%3A_k8s.node.name*N________key%3A_host*N______-_action%3A_insert*N________from*_attribute%3A_k8s.namespace.name*N________key%3A_namespace*N______-_action%3A_insert*N________from*_attribute%3A_k8s.container.name*N________key%3A_container*N______-_action%3A_insert*N________from*_attribute%3A_k8s.pod.name*N________key%3A_pod*N__attributes%2Fsubscription*_database%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_subscription*N________value%3A_database*N__attributes%2Fsubscription*_web%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_subscription*N________value%3A_web*N__attributes%2Ftenant*_database%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_tenant*N________value%3A_database*N__attributes%2Ftenant*_shared%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_tenant*N________value%3A_shared*N__attributes%2Ftenant*_web%3A*N____actions%3A*N______-_action%3A_insert*N________key%3A_tenant*N________value%3A_web*N__deltatocumulative%3A_%7B%7D*N__k8sattributes%3A*N____auth*_type%3A_serviceAccount*N____extract%3A*N______labels%3A*N________-_from%3A_pod*N__________key*_regex%3A_.***N__________tag*_name%3A_all*_labels*N______metadata%3A*N________-_k8s.pod.name*N________-_k8s.pod.uid*N________-_k8s.deployment.name*N________-_k8s.namespace.name*N________-_k8s.node.name*N________-_k8s.pod.start*_time*N____passthrough%3A_false*N____pod*_association%3A*N______-_sources%3A*N__________-_from%3A_resource*_attribute*N____________name%3A_k8s.namespace.name*N__________-_from%3A_resource*_attribute*N____________name%3A_k8s.pod.name*N__memory*_limiter%3A*N____check*_interval%3A_1s*N____limit*_percentage%3A_75*N____spike*_limit*_mib%3A_25*N__transform%2Fparse-nginx%3A*N____log*_statements%3A*N______-_conditions%3A_null*N________context%3A_log*N________statements%3A*N__________-_set*Cresource.attributes%5B%22parsed%22%5D%2C_ExtractPatterns*Cbody%2C_%22*C*QP*Lmethod*G*CGET%7CPUT*D*D%22*D*D*Nreceivers%3A*N__filelog%2Fshared%3A*N____exclude%3A*N______-_%2Fvar%2Flog%2Fpods%2F**%2Fotc-container%2F**.log*N____include%3A*N______-_%2Fvar%2Flog%2Fpods%2Fshared*_**%2F**%2F**.log*N____include*_file*_name%3A_false*N____include*_file*_path%3A_true*N____operators%3A*N______-_id%3A_get-format*N________routes%3A*N__________-_expr%3A_body_matches_%22%5E*B*B%7B%22*N____________output%3A_parser-docker*N__________-_expr%3A_body_matches_%22%5E%5B%5E_Z%5D*PZ%22*N____________output%3A_parser-containerd*N________type%3A_router*N______-_id%3A_parser-containerd*N________output%3A_extract*_metadata*_from*_filepath*N________regex%3A_%5E*C*QP*Ltime*G%5B%5E_%5EZ%5D*PZ*D_*C*QP*Lstream*Gstdout%7Cstderr*D_*C*QP*Llogtag*G%5B%5E_%5D***D_*Q*C*QP*Llog*G.***D*S*N________timestamp%3A*N__________layout%3A_*%22*.Y-*.m-*.dT*.H%3A*.M%3A*.S.*.LZ*%22*N__________parse*_from%3A_attributes.time*N________type%3A_regex*_parser*N______-_id%3A_parser-docker*N________output%3A_extract*_metadata*_from*_filepath*N________timestamp%3A*N__________layout%3A_*%22*.Y-*.m-*.dT*.H%3A*.M%3A*.S.*.LZ*%22*N__________parse*_from%3A_attributes.time*N________type%3A_json*_parser*N______-_cache%3A*N__________size%3A_128*N________id%3A_extract*_metadata*_from*_filepath*N________parse*_from%3A_attributes%5B%22log.file.path%22%5D*N________regex%3A_%5E.***B%2F*C*QP*Lnamespace*G%5B%5E*_%5D*P*D*_*C*QP*Lpod*_name*G%5B%5E*_%5D*P*D*_*C*QP*Luid*G%5Ba-f0-9-%5D*P*D*B%2F*C*QP*Lcontainer*_name*G%5B%5E*B%2F%5D*P*D*B%2F*C*QP*Lrestart*_count*G*Bd*P*D*B.log*S*N________type%3A_regex*_parser*N______-_from%3A_attributes.log*N________to%3A_body*N________type%3A_move*N______-_from%3A_attributes.stream*N________to%3A_attributes%5B%22log.iostream%22%5D*N________type%3A_move*N______-_from%3A_attributes.container*_name*N________to%3A_resource%5B%22k8s.container.name%22%5D*N________type%3A_move*N______-_from%3A_attributes.namespace*N________to%3A_resource%5B%22k8s.namespace.name%22%5D*N________type%3A_move*N______-_from%3A_attributes.pod*_name*N________to%3A_resource%5B%22k8s.pod.name%22%5D*N________type%3A_move*N______-_from%3A_attributes.restart*_count*N________to%3A_resource%5B%22k8s.container.restart*_count%22%5D*N________type%3A_move*N______-_from%3A_attributes.uid*N________to%3A_resource%5B%22k8s.pod.uid%22%5D*N________type%3A_move*N____retry*_on*_failure%3A*N______enabled%3A_true*N______max*_elapsed*_time%3A_0*N____start*_at%3A_end*Nservice%3A*N__pipelines%3A*N____logs%2Foutput*_database*_database*_database*_openobserve-database%3A*N______exporters%3A*N________-_otlp%2Fdatabase*_openobserve-database*N________-_count%2Foutput*_metrics*N______processors%3A*N________-_memory*_limiter*N________-_attributes%2Fexporter*_name*_openobserve-database*N______receivers%3A*N________-_routing%2Fsubscription*_database*_database*_outputs*N____logs%2Foutput*_web*_web*_web*_openobserve-web%3A*N______exporters%3A*N________-_otlp%2Fweb*_openobserve-web*N________-_count%2Foutput*_metrics*N______processors%3A*N________-_memory*_limiter*N________-_attributes%2Fexporter*_name*_openobserve-web*N______receivers%3A*N________-_routing%2Fsubscription*_web*_web*_outputs*N____logs%2Ftenant*_database%3A*N______exporters%3A*N________-_routing%2Ftenant*_database*_subscriptions*N________-_count%2Ftenant*_metrics*N______processors%3A*N________-_memory*_limiter*N________-_k8sattributes*N________-_attributes%2Ftenant*_database*N______receivers%3A*N________-_routing%2Fbridge*_shared-database*N____logs%2Ftenant*_database*_subscription*_database*_database%3A*N______exporters%3A*N________-_routing%2Fsubscription*_database*_database*_outputs*N______processors%3A*N________-_memory*_limiter*N________-_attributes%2Fsubscription*_database*N______receivers%3A*N________-_routing%2Ftenant*_database*_subscriptions*N____logs%2Ftenant*_shared%3A*N______exporters%3A*N________-_count%2Ftenant*_metrics*N________-_routing%2Fbridge*_shared-database*N________-_routing%2Fbridge*_shared-web*N______processors%3A*N________-_memory*_limiter*N________-_k8sattributes*N________-_attributes%2Ftenant*_shared*N________-_transform%2Fparse-nginx*N______receivers%3A*N________-_filelog%2Fshared*N____logs%2Ftenant*_web%3A*N______exporters%3A*N________-_routing%2Ftenant*_web*_subscriptions*N________-_count%2Ftenant*_metrics*N______processors%3A*N________-_memory*_limiter*N________-_k8sattributes*N________-_attributes%2Ftenant*_web*N______receivers%3A*N________-_routing%2Fbridge*_shared-web*N____logs%2Ftenant*_web*_subscription*_web*_web%3A*N______exporters%3A*N________-_routing%2Fsubscription*_web*_web*_outputs*N______processors%3A*N________-_memory*_limiter*N________-_attributes%2Fsubscription*_web*N______receivers%3A*N________-_routing%2Ftenant*_web*_subscriptions*N____metrics%2Foutput%3A*N______exporters%3A*N________-_prometheus%2Fmessage*_metrics*_exporter*N______processors%3A*N________-_memory*_limiter*N________-_deltatocumulative*N________-_attributes%2Fmetricattributes*N______receivers%3A*N________-_count%2Foutput*_metrics*N____metrics%2Ftenant%3A*N______exporters%3A*N________-_prometheus%2Fmessage*_metrics*_exporter*N______processors%3A*N________-_memory*_limiter*N________-_deltatocumulative*N________-_attributes%2Fmetricattributes*N______receivers%3A*N________-_count%2Ftenant*_metrics*N__telemetry%3A*N____metrics%3A*N______level%3A_detailed*N%7E)
