### PR TITLE
fix: add support for transform processor log-flattenning feature-gate

### DIFF
--- a/api/telemetry/v1alpha1/tenant_types.go
+++ b/api/telemetry/v1alpha1/tenant_types.go
@@ -32,6 +32,11 @@ type Transform struct {
 	// Name of the Transform processor
 	Name string `json:"name,omitempty"`
 
+	// When FlattenData is true, the processor provides each log record with a distinct copy
+	// of its resource and scope. Then, after applying all transformations,
+	// the log records are regrouped by resource and scope.
+	FlattenData bool `json:"flattenData,omitempty"`
+
 	// +kubebuilder:validation:Enum:=ignore;silent;propagate
 
 	// ErrorMode specifies how errors are handled while processing a statement

--- a/charts/telemetry-controller/crds/telemetry.kube-logging.dev_tenants.yaml
+++ b/charts/telemetry-controller/crds/telemetry.kube-logging.dev_tenants.yaml
@@ -190,6 +190,12 @@ spec:
                     - silent
                     - propagate
                     type: string
+                  flattenData:
+                    description: |-
+                      When FlattenData is true, the processor provides each log record with a distinct copy
+                      of its resource and scope. Then, after applying all transformations,
+                      the log records are regrouped by resource and scope.
+                    type: boolean
                   logStatements:
                     items:
                       description: |-

--- a/config/crd/bases/telemetry.kube-logging.dev_tenants.yaml
+++ b/config/crd/bases/telemetry.kube-logging.dev_tenants.yaml
@@ -190,6 +190,12 @@ spec:
                     - silent
                     - propagate
                     type: string
+                  flattenData:
+                    description: |-
+                      When FlattenData is true, the processor provides each log record with a distinct copy
+                      of its resource and scope. Then, after applying all transformations,
+                      the log records are regrouped by resource and scope.
+                    type: boolean
                   logStatements:
                     items:
                       description: |-

--- a/docs/examples/tenant-to-tenant-routing/pipeline.yaml
+++ b/docs/examples/tenant-to-tenant-routing/pipeline.yaml
@@ -17,6 +17,7 @@ metadata:
 spec:
   transform:
     name: parse-nginx
+    flattenData: true
     logStatements:
       - context: log
         statements:

--- a/e2e/testdata/tenants_with_bridges/tenants_with_bridges.yaml
+++ b/e2e/testdata/tenants_with_bridges/tenants_with_bridges.yaml
@@ -43,6 +43,7 @@ metadata:
 spec:
   transform:
     name: parse-nginx
+    flattenData: true
     logStatements:
       - context: log
         statements:

--- a/internal/controller/telemetry/collector_controller.go
+++ b/internal/controller/telemetry/collector_controller.go
@@ -211,7 +211,7 @@ func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	otelConfig := otelConfigInput.AssembleConfig(ctx)
+	otelConfig, additionalArgs := otelConfigInput.AssembleConfig(ctx)
 	if err := validator.ValidateAssembledConfig(otelConfig); err != nil {
 		logger.Error(errors.WithStack(err), "invalid otel config")
 
@@ -241,6 +241,7 @@ func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			Mode:            otelv1beta1.ModeDaemonSet,
 			OpenTelemetryCommonFields: otelv1beta1.OpenTelemetryCommonFields{
 				Image:          axoflowOtelCollectorImageRef,
+				Args:           additionalArgs,
 				ServiceAccount: saName.Name,
 				VolumeMounts: []corev1.VolumeMount{
 					{

--- a/internal/controller/telemetry/otel_conf_gen/otel_conf_gen_test.go
+++ b/internal/controller/telemetry/otel_conf_gen/otel_conf_gen_test.go
@@ -310,7 +310,7 @@ func TestOtelColConfComplex(t *testing.T) {
 	// Config
 
 	// The receiver and exporter entries are not serialized because of tags on the underlying data structure. The tests won't contain them, this is a known issue.
-	generatedConfig := inputCfg.AssembleConfig(context.TODO())
+	generatedConfig, _ := inputCfg.AssembleConfig(context.TODO())
 	actualJSONBytes, err1 := json.Marshal(generatedConfig)
 	if err1 != nil {
 		t.Fatalf("error %v", err1)

--- a/internal/controller/telemetry/pipeline/components/processor/transform_processor.go
+++ b/internal/controller/telemetry/pipeline/components/processor/transform_processor.go
@@ -30,6 +30,7 @@ type TransformProcessorStatement struct {
 
 type TransformProcessor struct {
 	ErrorMode        components.ErrorMode          `json:"error_mode,omitempty"`
+	FlattenData      bool                          `json:"flatten_data,omitempty"`
 	TraceStatements  []TransformProcessorStatement `json:"trace_statements,omitempty"`
 	MetricStatements []TransformProcessorStatement `json:"metric_statements,omitempty"`
 	LogStatements    []TransformProcessorStatement `json:"log_statements,omitempty"`
@@ -38,6 +39,7 @@ type TransformProcessor struct {
 func GenerateTransformProcessorForTenant(tenant v1alpha1.Tenant) TransformProcessor {
 	return TransformProcessor{
 		ErrorMode:        components.ErrorMode(tenant.Spec.Transform.ErrorMode),
+		FlattenData:      tenant.Spec.Transform.FlattenData,
 		TraceStatements:  convertAPIStatements(tenant.Spec.Transform.TraceStatements),
 		MetricStatements: convertAPIStatements(tenant.Spec.Transform.MetricStatements),
 		LogStatements:    convertAPIStatements(tenant.Spec.Transform.LogStatements),


### PR DESCRIPTION
Previously there was an issue, when the `Bridge` CRD was added, it was observed by @tarokkk in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36360

This PR fixes that by adding support for the `transform.flatten.logs` feature-gate.