### PR TITLE
Fix: confgen testing receivers/exporters

### DIFF
--- a/internal/controller/telemetry/otel_conf_gen/otel_col_conf_test_fixtures/complex.yaml
+++ b/internal/controller/telemetry/otel_conf_gen/otel_col_conf_test_fixtures/complex.yaml
@@ -43,7 +43,7 @@ connectors:
     - condition: "true"
       pipelines:
       - logs/output_example-tenant-b-ns_subscription-example-3_collector_fluentforward-test-output
-      - logs/output_example-tenant-b-ns_subscription-example-3_collector_otlp-test-output-2
+      - logs/output_example-tenant-b-ns_subscription-example-3_collector_otlp-test-output-3
   routing/tenant_example-tenant-a_subscriptions:
     table:
     - condition: "true"
@@ -93,6 +93,17 @@ exporters:
       storage: file_storage/example-tenant-a
     tls:
       insecure: true
+  otlp/collector_otlp-test-output-3:
+    endpoint: "receiver-collector.example-tenant-b-ns.svc.cluster.local:4317"
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0.0
+    sending_queue:
+      enabled: true
+      queue_size: 100.0
+      storage: "file_storage/example-tenant-b"
+    tls:
+      insecure: true
   otlphttp/collector_loki-test-output:
     endpoint: loki.example-tenant-a-ns.svc.cluster.local:4317
     retry_on_failure:
@@ -136,6 +147,11 @@ processors:
     - action: insert
       key: exporter
       value: otlp/collector_otlp-test-output-2
+  attributes/exporter_name_otlp-test-output-3:
+    actions:
+    - action: "insert"
+      key: "exporter"
+      value: "otlp/collector_otlp-test-output-3"
   attributes/metricattributes:
     actions:
     - action: insert
@@ -389,13 +405,13 @@ service:
       - attributes/exporter_name_fluentforward-test-output
       receivers:
       - routing/subscription_example-tenant-b-ns_subscription-example-3_outputs
-    logs/output_example-tenant-b-ns_subscription-example-3_collector_otlp-test-output-2:
+    logs/output_example-tenant-b-ns_subscription-example-3_collector_otlp-test-output-3:
       exporters:
-      - otlp/collector_otlp-test-output-2
+      - otlp/collector_otlp-test-output-3
       - count/output_metrics
       processors:
       - memory_limiter
-      - attributes/exporter_name_otlp-test-output-2
+      - attributes/exporter_name_otlp-test-output-3
       receivers:
       - routing/subscription_example-tenant-b-ns_subscription-example-3_outputs
     logs/tenant_example-tenant-a:

--- a/internal/controller/telemetry/otel_conf_gen/otel_col_conf_test_fixtures/complex.yaml
+++ b/internal/controller/telemetry/otel_conf_gen/otel_col_conf_test_fixtures/complex.yaml
@@ -55,7 +55,57 @@ connectors:
     - condition: "true"
       pipelines:
       - logs/tenant_example-tenant-b_subscription_example-tenant-b-ns_subscription-example-3
-exporters: {}
+exporters:
+  fluentforwardexporter/collector_fluentforward-test-output:
+    endpoint:
+      tcp_addr: fluentd.example-tenant-b-ns.svc.cluster.local:24224
+      validate_tcp_resolution: false
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0
+    sending_queue:
+      enabled: true
+      queue_size: 100
+      storage: file_storage/example-tenant-b
+    tls:
+      insecure: true
+  otlp/collector_otlp-test-output:
+    auth:
+      authenticator: bearertokenauth/collector_otlp-test-output
+    endpoint: receiver-collector.example-tenant-a-ns.svc.cluster.local:4317
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0
+    sending_queue:
+      enabled: true
+      queue_size: 100
+      storage: file_storage/example-tenant-a
+    tls:
+      insecure: true
+  otlp/collector_otlp-test-output-2:
+    endpoint: receiver-collector.example-tenant-a-ns.svc.cluster.local:4317
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0
+    sending_queue:
+      enabled: true
+      queue_size: 100
+      storage: file_storage/example-tenant-a
+    tls:
+      insecure: true
+  otlphttp/collector_loki-test-output:
+    endpoint: loki.example-tenant-a-ns.svc.cluster.local:4317
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0
+    sending_queue:
+      enabled: true
+      queue_size: 100
+      storage: file_storage/example-tenant-a
+    tls:
+      insecure: true
+  prometheus/message_metrics_exporter:
+    endpoint: :9999
 extensions:
   bearertokenauth/collector_otlp-test-output:
     token: testtoken
@@ -175,7 +225,127 @@ processors:
     check_interval: 1s
     limit_percentage: 75
     spike_limit_percentage: 25
-receivers: {}
+receivers:
+  filelog/example-tenant-a:
+    exclude:
+    - /var/log/pods/*/otc-container/*.log
+    include:
+    - /var/log/pods/example-tenant-a_*/*/*.log
+    include_file_name: false
+    include_file_path: true
+    operators:
+    - id: get-format
+      routes:
+      - expr: body matches "^\\{"
+        output: parser-docker
+      - expr: body matches "^[^ Z]+Z"
+        output: parser-containerd
+      type: router
+    - id: parser-containerd
+      output: extract_metadata_from_filepath
+      regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+      timestamp:
+        layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+        parse_from: attributes.time
+      type: regex_parser
+    - id: parser-docker
+      output: extract_metadata_from_filepath
+      timestamp:
+        layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+        parse_from: attributes.time
+      type: json_parser
+    - cache:
+        size: 128
+      id: extract_metadata_from_filepath
+      parse_from: attributes["log.file.path"]
+      regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9-]+)\/(?P<container_name>[^\/]+)\/(?P<restart_count>\d+)\.log$
+      type: regex_parser
+    - from: attributes.log
+      to: body
+      type: move
+    - from: attributes.stream
+      to: attributes["log.iostream"]
+      type: move
+    - from: attributes.container_name
+      to: resource["k8s.container.name"]
+      type: move
+    - from: attributes.namespace
+      to: resource["k8s.namespace.name"]
+      type: move
+    - from: attributes.pod_name
+      to: resource["k8s.pod.name"]
+      type: move
+    - from: attributes.restart_count
+      to: resource["k8s.container.restart_count"]
+      type: move
+    - from: attributes.uid
+      to: resource["k8s.pod.uid"]
+      type: move
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0
+    start_at: end
+    storage: file_storage/example-tenant-a
+  filelog/example-tenant-b:
+    exclude:
+    - /var/log/pods/*/otc-container/*.log
+    include:
+    - /var/log/pods/example-tenant-b_*/*/*.log
+    include_file_name: false
+    include_file_path: true
+    operators:
+    - id: get-format
+      routes:
+      - expr: body matches "^\\{"
+        output: parser-docker
+      - expr: body matches "^[^ Z]+Z"
+        output: parser-containerd
+      type: router
+    - id: parser-containerd
+      output: extract_metadata_from_filepath
+      regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+      timestamp:
+        layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+        parse_from: attributes.time
+      type: regex_parser
+    - id: parser-docker
+      output: extract_metadata_from_filepath
+      timestamp:
+        layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+        parse_from: attributes.time
+      type: json_parser
+    - cache:
+        size: 128
+      id: extract_metadata_from_filepath
+      parse_from: attributes["log.file.path"]
+      regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9-]+)\/(?P<container_name>[^\/]+)\/(?P<restart_count>\d+)\.log$
+      type: regex_parser
+    - from: attributes.log
+      to: body
+      type: move
+    - from: attributes.stream
+      to: attributes["log.iostream"]
+      type: move
+    - from: attributes.container_name
+      to: resource["k8s.container.name"]
+      type: move
+    - from: attributes.namespace
+      to: resource["k8s.namespace.name"]
+      type: move
+    - from: attributes.pod_name
+      to: resource["k8s.pod.name"]
+      type: move
+    - from: attributes.restart_count
+      to: resource["k8s.container.restart_count"]
+      type: move
+    - from: attributes.uid
+      to: resource["k8s.pod.uid"]
+      type: move
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0
+    start_at: end
+    storage: file_storage/example-tenant-b
 service:
   extensions:
   - bearertokenauth/collector_otlp-test-output

--- a/internal/controller/telemetry/otel_conf_gen/otel_conf_gen_test.go
+++ b/internal/controller/telemetry/otel_conf_gen/otel_conf_gen_test.go
@@ -91,7 +91,7 @@ func TestOtelColConfComplex(t *testing.T) {
 				Condition: "true",
 				Outputs: []v1alpha1.NamespacedName{
 					{
-						Name:      "otlp-test-output-2",
+						Name:      "otlp-test-output-3",
 						Namespace: "collector",
 					},
 					{
@@ -238,6 +238,24 @@ func TestOtelColConfComplex(t *testing.T) {
 							OTLPGRPC: &v1alpha1.OTLPGRPC{
 								GRPCClientConfig: v1alpha1.GRPCClientConfig{
 									Endpoint: utils.ToPtr("receiver-collector.example-tenant-a-ns.svc.cluster.local:4317"),
+									TLSSetting: &v1alpha1.TLSClientSetting{
+										Insecure: true,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Output: v1alpha1.Output{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "otlp-test-output-3",
+							Namespace: "collector",
+						},
+						Spec: v1alpha1.OutputSpec{
+							OTLPGRPC: &v1alpha1.OTLPGRPC{
+								GRPCClientConfig: v1alpha1.GRPCClientConfig{
+									Endpoint: utils.ToPtr("receiver-collector.example-tenant-b-ns.svc.cluster.local:4317"),
 									TLSSetting: &v1alpha1.TLSClientSetting{
 										Insecure: true,
 									},

--- a/internal/controller/telemetry/pipeline/components/connector/count_connector.go
+++ b/internal/controller/telemetry/pipeline/components/connector/count_connector.go
@@ -14,13 +14,15 @@
 
 package connector
 
+import "github.com/kube-logging/telemetry-controller/internal/controller/telemetry/utils"
+
 type CountConnectorAttributeConfig struct {
-	Key          string `json:"key,omitempty"`
-	DefaultValue string `json:"default_value,omitempty"`
+	Key          *string `json:"key,omitempty"`
+	DefaultValue *string `json:"default_value,omitempty"`
 }
 
 type CountConnectorMetricInfo struct {
-	Description        string                          `json:"description,omitempty"`
+	Description        *string                         `json:"description,omitempty"`
 	Conditions         []string                        `json:"conditions,omitempty"`
 	Attributes         []CountConnectorAttributeConfig `json:"attributes,omitempty"`
 	ResourceAttributes []CountConnectorAttributeConfig `json:"resource_attributes,omitempty"`
@@ -31,28 +33,28 @@ func GenerateCountConnectors() map[string]any {
 	countConnectors["count/tenant_metrics"] = map[string]any{
 		"logs": map[string]CountConnectorMetricInfo{
 			"telemetry_controller_tenant_log_count": {
-				Description: "The number of logs from each tenant pipeline.",
+				Description: utils.ToPtr("The number of logs from each tenant pipeline."),
 				Attributes: []CountConnectorAttributeConfig{{
-					Key: "tenant",
+					Key: utils.ToPtr("tenant"),
 				}},
 				ResourceAttributes: []CountConnectorAttributeConfig{
 					{
-						Key: "k8s.namespace.name",
+						Key: utils.ToPtr("k8s.namespace.name"),
 					},
 					{
-						Key: "k8s.node.name",
+						Key: utils.ToPtr("k8s.node.name"),
 					},
 					{
-						Key: "k8s.container.name",
+						Key: utils.ToPtr("k8s.container.name"),
 					},
 					{
-						Key: "k8s.pod.name",
+						Key: utils.ToPtr("k8s.pod.name"),
 					},
 					{
-						Key: "k8s.pod.labels.app.kubernetes.io/name",
+						Key: utils.ToPtr("k8s.pod.labels.app.kubernetes.io/name"),
 					},
 					{
-						Key: "k8s.pod.labels.app",
+						Key: utils.ToPtr("k8s.pod.labels.app"),
 					},
 				},
 			},
@@ -62,33 +64,33 @@ func GenerateCountConnectors() map[string]any {
 	countConnectors["count/output_metrics"] = map[string]any{
 		"logs": map[string]CountConnectorMetricInfo{
 			"telemetry_controller_output_log_count": {
-				Description: "The number of logs sent out from each exporter.",
+				Description: utils.ToPtr("The number of logs sent out from each exporter."),
 				Attributes: []CountConnectorAttributeConfig{
 					{
-						Key: "tenant",
+						Key: utils.ToPtr("tenant"),
 					}, {
-						Key: "subscription",
+						Key: utils.ToPtr("subscription"),
 					}, {
-						Key: "exporter",
+						Key: utils.ToPtr("exporter"),
 					}},
 				ResourceAttributes: []CountConnectorAttributeConfig{
 					{
-						Key: "k8s.namespace.name",
+						Key: utils.ToPtr("k8s.namespace.name"),
 					},
 					{
-						Key: "k8s.node.name",
+						Key: utils.ToPtr("k8s.node.name"),
 					},
 					{
-						Key: "k8s.container.name",
+						Key: utils.ToPtr("k8s.container.name"),
 					},
 					{
-						Key: "k8s.pod.name",
+						Key: utils.ToPtr("k8s.pod.name"),
 					},
 					{
-						Key: "k8s.pod.labels.app.kubernetes.io/name",
+						Key: utils.ToPtr("k8s.pod.labels.app.kubernetes.io/name"),
 					},
 					{
-						Key: "k8s.pod.labels.app",
+						Key: utils.ToPtr("k8s.pod.labels.app"),
 					},
 				},
 			},


### PR DESCRIPTION
Outputs should belong to a single tenant
The current test case breaks this invariant, that's why it had to be changed.
Once the Output visibility issue is solved we can refactor/rethink this test case as well
since this is getting convoluted.