### PR TITLE
chore: migrate to v2 golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,67 +1,37 @@
+version: "2"
 run:
-  timeout: 5m
+  timeout: 10m
   allow-parallel-runners: true
 
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/kube-logging/telemetry-controller)
-  goimports:
-    local-prefixes: github.com/kube-logging/telemetry-controller
-  misspell:
-    locale: US
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
-
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "pkg/resources/*"
-      linters:
-        - dupl
-        - lll
-    - path: "controllers/*"
-      linters:
-        - dupl
-        - lll
-        - gci
-    - path: "cmd/main.go"
-      linters:
-        - gci
+formatters:
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/kube-logging/telemetry-controller)
+    goimports:
+      local-prefixes:
+        - github.com/kube-logging/telemetry-controller
+    gofmt:
+      simplify: true
+    gofumpt:
+      extra-rules: false
 
 linters:
-  disable-all: true
+  settings:
+    misspell:
+      locale: US
+    gocyclo:
+      min-complexity: 15
   enable:
+    - staticcheck
     - bodyclose
-    - copyloopvar
-    - dupl
     - errcheck
-    - gci
-    - goconst
-    - gocyclo
-    - gofmt
-    - gofumpt
-    - goimports
-    - gosimple
-    - govet
     - ineffassign
-    - lll
     - misspell
     - nolintlint
-    - prealloc
-    - staticcheck
-    - typecheck
     - unconvert
-    - unparam 
+    - unparam
     - unused
     - whitespace

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CONTROLLER_TOOLS_VERSION := 0.17.2
 KUSTOMIZE_VERSION := 5.5.0
 
 # renovate: datasource=github-releases depName=golangci/golangci-lint versioning=semver
-GOLANGCI_LINT_VERSION := 1.64.8
+GOLANGCI_LINT_VERSION := 2.0.2
 
 # renovate: datasource=github-releases depName=kubernetes-sigs/kind versioning=semver
 KIND_VERSION ?= 0.26.0

--- a/api/telemetry/v1alpha1/tenant_types.go
+++ b/api/telemetry/v1alpha1/tenant_types.go
@@ -110,10 +110,10 @@ type TenantSpec struct {
 
 	// If true, logs are collected from all namespaces.
 	// Cannot be used together with LogSourceNamespaceSelectors.
-	SelectFromAllNamespaces bool `json:"selectFromAllNamespaces,omitempty"`
-	Transform               `json:"transform,omitempty"`
-	RouteConfig             `json:"routeConfig,omitempty"`
-	PersistenceConfig       `json:"persistenceConfig,omitempty"`
+	SelectFromAllNamespaces bool              `json:"selectFromAllNamespaces,omitempty"`
+	Transform               Transform         `json:"transform,omitempty"`
+	RouteConfig             RouteConfig       `json:"routeConfig,omitempty"`
+	PersistenceConfig       PersistenceConfig `json:"persistenceConfig,omitempty"`
 }
 
 // TenantStatus defines the observed state of Tenant

--- a/controllers/telemetry/collector_controller.go
+++ b/controllers/telemetry/collector_controller.go
@@ -91,7 +91,7 @@ func (r *CollectorReconciler) buildConfigInputForCollector(ctx context.Context, 
 		tenantSubscriptionMap[tenant.Name] = subscriptionNames
 		for _, subsName := range subscriptionNames {
 			queriedSubs := &v1alpha1.Subscription{}
-			if err = r.Client.Get(ctx, types.NamespacedName(subsName), queriedSubs); err != nil {
+			if err = r.Get(ctx, types.NamespacedName(subsName), queriedSubs); err != nil {
 				logger.Error(errors.WithStack(err), "failed getting subscriptions for tenant", "tenant", tenant.Name)
 				return otelcolconfgen.OtelColConfigInput{}, err
 			}
@@ -101,7 +101,7 @@ func (r *CollectorReconciler) buildConfigInputForCollector(ctx context.Context, 
 		bridgeNames := tenant.Status.ConnectedBridges
 		for _, bridgeName := range bridgeNames {
 			queriedBridge := &v1alpha1.Bridge{}
-			if err = r.Client.Get(ctx, types.NamespacedName{Name: bridgeName}, queriedBridge); err != nil {
+			if err = r.Get(ctx, types.NamespacedName{Name: bridgeName}, queriedBridge); err != nil {
 				logger.Error(errors.WithStack(err), "failed getting bridges for tenant", "tenant", tenant.Name)
 				return otelcolconfgen.OtelColConfigInput{}, err
 			}
@@ -117,7 +117,7 @@ func (r *CollectorReconciler) buildConfigInputForCollector(ctx context.Context, 
 			outputWithSecretData := components.OutputWithSecretData{}
 
 			queriedOutput := &v1alpha1.Output{}
-			if err = r.Client.Get(ctx, types.NamespacedName(outputName), queriedOutput); err != nil {
+			if err = r.Get(ctx, types.NamespacedName(outputName), queriedOutput); err != nil {
 				logger.Error(errors.WithStack(err), "failed getting outputs for subscription", "subscription", subscription.NamespacedName().String())
 				return otelcolconfgen.OtelColConfigInput{}, err
 			}
@@ -150,7 +150,7 @@ func (r *CollectorReconciler) populateSecretForOutput(ctx context.Context, queri
 	if queriedOutput.Spec.Authentication != nil {
 		if queriedOutput.Spec.Authentication.BasicAuth != nil && queriedOutput.Spec.Authentication.BasicAuth.SecretRef != nil {
 			queriedSecret := &corev1.Secret{}
-			if err := r.Client.Get(ctx, types.NamespacedName{Namespace: queriedOutput.Spec.Authentication.BasicAuth.SecretRef.Namespace, Name: queriedOutput.Spec.Authentication.BasicAuth.SecretRef.Name}, queriedSecret); err != nil {
+			if err := r.Get(ctx, types.NamespacedName{Namespace: queriedOutput.Spec.Authentication.BasicAuth.SecretRef.Namespace, Name: queriedOutput.Spec.Authentication.BasicAuth.SecretRef.Name}, queriedSecret); err != nil {
 				logger.Error(errors.WithStack(err), "failed getting secrets for output", "output", queriedOutput.NamespacedName().String())
 				return err
 			}
@@ -158,7 +158,7 @@ func (r *CollectorReconciler) populateSecretForOutput(ctx context.Context, queri
 		}
 		if queriedOutput.Spec.Authentication.BearerAuth != nil && queriedOutput.Spec.Authentication.BearerAuth.SecretRef != nil {
 			queriedSecret := &corev1.Secret{}
-			if err := r.Client.Get(ctx, types.NamespacedName{Namespace: queriedOutput.Spec.Authentication.BearerAuth.SecretRef.Namespace, Name: queriedOutput.Spec.Authentication.BearerAuth.SecretRef.Name}, queriedSecret); err != nil {
+			if err := r.Get(ctx, types.NamespacedName{Namespace: queriedOutput.Spec.Authentication.BearerAuth.SecretRef.Namespace, Name: queriedOutput.Spec.Authentication.BearerAuth.SecretRef.Name}, queriedSecret); err != nil {
 				logger.Error(errors.WithStack(err), "failed getting secrets for output", "output", queriedOutput.NamespacedName().String())
 				return err
 			}
@@ -285,7 +285,7 @@ func (r *CollectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Collector{}).
-		Watches(&v1alpha1.Tenant{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) (requests []reconcile.Request) {
+		Watches(&v1alpha1.Tenant{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) (requests []reconcile.Request) {
 			logger := log.FromContext(ctx)
 
 			collectors := &v1alpha1.CollectorList{}
@@ -301,7 +301,7 @@ func (r *CollectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 			return
 		})).
-		Watches(&v1alpha1.Subscription{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) (requests []reconcile.Request) {
+		Watches(&v1alpha1.Subscription{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) (requests []reconcile.Request) {
 			logger := log.FromContext(ctx)
 
 			collectors := &v1alpha1.CollectorList{}
@@ -317,7 +317,7 @@ func (r *CollectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 			return
 		})).
-		Watches(&v1alpha1.Bridge{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) (requests []reconcile.Request) {
+		Watches(&v1alpha1.Bridge{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) (requests []reconcile.Request) {
 			logger := log.FromContext(ctx)
 
 			collectors := &v1alpha1.CollectorList{}
@@ -333,7 +333,7 @@ func (r *CollectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 			return
 		})).
-		Watches(&v1alpha1.Output{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) (requests []reconcile.Request) {
+		Watches(&v1alpha1.Output{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) (requests []reconcile.Request) {
 			logger := log.FromContext(ctx)
 
 			collectors := &v1alpha1.CollectorList{}
@@ -349,7 +349,7 @@ func (r *CollectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 			return
 		})).
-		Watches(&corev1.Namespace{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) (requests []reconcile.Request) {
+		Watches(&corev1.Namespace{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) (requests []reconcile.Request) {
 			logger := log.FromContext(ctx)
 
 			collectors := &v1alpha1.CollectorList{}
@@ -365,7 +365,7 @@ func (r *CollectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 			return
 		})).
-		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) (requests []reconcile.Request) {
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) (requests []reconcile.Request) {
 			logger := log.FromContext(ctx)
 
 			collectors := &v1alpha1.CollectorList{}
@@ -537,7 +537,7 @@ func (r *CollectorReconciler) getTenantsMatchingSelectors(ctx context.Context, l
 		LabelSelector: selector,
 	}
 
-	if err := r.Client.List(ctx, &tenantsForSelector, listOpts); client.IgnoreNotFound(err) != nil {
+	if err := r.List(ctx, &tenantsForSelector, listOpts); client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}
 

--- a/controllers/telemetry/controller_integration_test.go
+++ b/controllers/telemetry/controller_integration_test.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //nolint: revive
+	. "github.com/onsi/gomega"    //nolint: revive
 	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/controllers/telemetry/suite_test.go
+++ b/controllers/telemetry/suite_test.go
@@ -21,8 +21,8 @@ import (
 	"runtime"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //nolint: revive
+	. "github.com/onsi/gomega"    //nolint: revive
 	"github.com/onsi/gomega/format"
 	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/pkg/resources/otel_conf_gen/pipeline/components/exporter/otlp_exporter.go
+++ b/pkg/resources/otel_conf_gen/pipeline/components/exporter/otlp_exporter.go
@@ -40,8 +40,8 @@ func (w *OTLPGRPCWrapper) mapToOTLPGRPCWrapper(apiConfig *v1alpha1.OTLPGRPC) {
 	w.QueueConfig.setDefaultQueueSettings(apiConfig.QueueConfig)
 	w.RetryConfig.setDefaultBackOffConfig(apiConfig.RetryConfig)
 
-	if apiConfig.TimeoutSettings.Timeout != nil {
-		w.TimeoutSettings.Timeout = apiConfig.TimeoutSettings.Timeout
+	if apiConfig.Timeout != nil {
+		w.Timeout = apiConfig.Timeout
 	}
 	w.GRPCClientConfig = apiConfig.GRPCClientConfig
 }

--- a/pkg/resources/otel_conf_gen/pipeline/components/exporter/otlphttp_exporter.go
+++ b/pkg/resources/otel_conf_gen/pipeline/components/exporter/otlphttp_exporter.go
@@ -69,16 +69,16 @@ func GenerateOTLPHTTPExporters(ctx context.Context, resourceRelations components
 					}
 				}
 			}
-			otlpHttpValuesMarshaled, err := json.Marshal(internalConfig)
+			otlpHTTPValuesMarshaled, err := json.Marshal(internalConfig)
 			if err != nil {
 				logger.Error(errors.New("failed to compile config for output"), "failed to compile config for output %q", output.Output.NamespacedName().String())
 			}
-			var otlpHttpValues map[string]any
-			if err := json.Unmarshal(otlpHttpValuesMarshaled, &otlpHttpValues); err != nil {
+			var otlpHTTPValues map[string]any
+			if err := json.Unmarshal(otlpHTTPValuesMarshaled, &otlpHTTPValues); err != nil {
 				logger.Error(errors.New("failed to compile config for output"), "failed to compile config for output %q", output.Output.NamespacedName().String())
 			}
 
-			result[components.GetExporterNameForOutput(output.Output)] = otlpHttpValues
+			result[components.GetExporterNameForOutput(output.Output)] = otlpHTTPValues
 		}
 	}
 

--- a/pkg/resources/otel_conf_gen/pipeline/components/receiver/filelog_receiver.go
+++ b/pkg/resources/otel_conf_gen/pipeline/components/receiver/filelog_receiver.go
@@ -114,7 +114,7 @@ func GenerateDefaultKubernetesReceiver(namespaces []string, tenant v1alpha1.Tena
 			"max_elapsed_time": 0,
 		},
 	}
-	if tenant.Spec.EnableFileStorage {
+	if tenant.Spec.PersistenceConfig.EnableFileStorage {
 		k8sReceiver["storage"] = fmt.Sprintf("file_storage/%s", tenant.Name)
 	}
 


### PR DESCRIPTION
- Migrates golangci-lint to v2.
- Adds sensible default linters.
- Fixes linter errors.

