### PR TITLE
fix(controller): handle k8s 409 conflict as transient requeue

### DIFF
--- a/controllers/telemetry/collector_controller.go
+++ b/controllers/telemetry/collector_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cisco-open/operator-tools/pkg/reconciler"
 	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -38,7 +39,10 @@ import (
 	"github.com/kube-logging/telemetry-controller/pkg/sdk/utils"
 )
 
-const requeueDelayOnFailedTenant = 20 * time.Second
+const (
+	requeueDelayOnFailedTenant = 20 * time.Second
+	requeueDelayOnConflict     = 1 * time.Second
+)
 
 // CollectorReconciler reconciles a Collector object
 type CollectorReconciler struct {
@@ -132,6 +136,10 @@ func (r *CollectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // handleTenantReconcileError handles errors that occur during reconciliation steps
 func (r *CollectorReconciler) handleCollectorReconcileError(ctx context.Context, baseManager *manager.BaseManager, collector *v1alpha1.Collector, err error) (ctrl.Result, error) {
 	switch {
+	case apierrors.IsConflict(err): // Stale resourceVersion, most probably otel-operator raced us. Requeue after a short delay to let otel-operator finish its work``.
+		baseManager.Info("optimistic concurrency conflict, requeueing", "name", collector.Name)
+		return ctrl.Result{RequeueAfter: requeueDelayOnConflict}, nil
+
 	case errors.Is(err, manager.ErrTenantFailed): // This error indicates that the tenant is in a failed state, and we should requeue after a delay.
 		return ctrl.Result{RequeueAfter: requeueDelayOnFailedTenant}, nil
 

--- a/controllers/telemetry/route_controller.go
+++ b/controllers/telemetry/route_controller.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"emperror.dev/errors"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -208,7 +208,7 @@ func (r *RouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		&v1alpha1.Subscription{},
 		&v1alpha1.Output{},
 		&v1alpha1.Bridge{},
-		&apiv1.Namespace{},
+		&corev1.Namespace{},
 	}
 	for _, resource := range watchedResources {
 		builder = builder.Watches(resource, enqueueAllTenants)


### PR DESCRIPTION
Fixes an issue where TC and the OTel-operator made changes to the collector CR on top of each-other.