### PR TITLE
fix: gate custom components if not using own image

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,6 @@
   "companyAnnouncements": [
     "Welcome to the Telemetry-controller project!\nIf you have any questions or need assistance, feel free to reach out to the maintainers or the community.\nWe are excited to have you on board and look forward to your contributions."
   ],
-  "model": "sonnet",
   "cleanupPeriodDays": 14,
   "env": {
     "DISABLE_TELEMETRY": "1",
@@ -78,7 +77,6 @@
       "Read(./**/tmp/**)",
       "Bash(rm -rf *)",
       "Bash(rm -fr *)",
-      "Bash(git push *)",
       "Bash(*exec*)",
       "Bash(sudo *)",
       "Bash(*chmod 777*)",
@@ -95,10 +93,7 @@
   "enableAllProjectMcpServers": true,
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
-    "feature-dev@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
-    "security-guidance@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true,
-    "gopls-lsp@claude-plugins-official": true
+    "security-guidance@claude-plugins-official": true
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ go.work.sum
 devspace.yaml
 
 .envrc
+
+**/settings.local.json
+**/CLAUDE.local.md

--- a/pkg/resources/manager/collector_manager.go
+++ b/pkg/resources/manager/collector_manager.go
@@ -46,8 +46,9 @@ import (
 )
 
 const (
-	otelCollectorKind            = "OpenTelemetryCollector"
-	axoflowOtelCollectorImageRef = "ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:0.152.0-axoflow.1"
+	otelCollectorKind             = "OpenTelemetryCollector"
+	axoflowOtelCollectorImageRepo = "ghcr.io/axoflow/axoflow-otel-collector"
+	axoflowOtelCollectorImageRef  = axoflowOtelCollectorImageRepo + "/axoflow-otel-collector:0.152.0-axoflow.1"
 )
 
 var (
@@ -121,6 +122,11 @@ func (c *CollectorManager) BuildConfigInputForCollector(ctx context.Context, col
 		}
 	}
 
+	var collectorImage string
+	if collector.Spec.OtelCommonFields != nil {
+		collectorImage = collector.Spec.OtelCommonFields.Image
+	}
+
 	return otelcolconfgen.OtelColConfigInput{
 		ResourceRelations: components.ResourceRelations{
 			Tenants:               tenants,
@@ -130,9 +136,10 @@ func (c *CollectorManager) BuildConfigInputForCollector(ctx context.Context, col
 			TenantSubscriptionMap: tenantSubscriptionMap,
 			SubscriptionOutputMap: subscriptionOutputMap,
 		},
-		Debug:         utils.DerefOrZero(collector.Spec.Debug),
-		DryRunMode:    utils.DerefOrZero(collector.Spec.DryRunMode),
-		MemoryLimiter: *collector.Spec.MemoryLimiter,
+		Debug:                 utils.DerefOrZero(collector.Spec.Debug),
+		DryRunMode:            utils.DerefOrZero(collector.Spec.DryRunMode),
+		MemoryLimiter:         *collector.Spec.MemoryLimiter,
+		IsAxoflowDistribution: isAxoflowDistribution(collectorImage),
 	}, nil
 }
 
@@ -592,4 +599,10 @@ func setOtelCommonFieldsDefaults(otelCommonFields *otelv1beta1.OpenTelemetryComm
 
 func authSecretName(collectorName string) string {
 	return fmt.Sprintf("otelcollector-%s-auth", collectorName)
+}
+
+func isAxoflowDistribution(image string) bool {
+	return image == "" ||
+		strings.HasPrefix(image, axoflowOtelCollectorImageRepo+"/") ||
+		strings.HasPrefix(image, axoflowOtelCollectorImageRepo+":")
 }

--- a/pkg/resources/manager/collector_manager_test.go
+++ b/pkg/resources/manager/collector_manager_test.go
@@ -195,3 +195,24 @@ func TestSetOtelCommonFieldsDefaults(t *testing.T) {
 		})
 	}
 }
+
+func TestIsAxoflowDistribution(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		expected bool
+	}{
+		{name: "Empty image uses axoflow default", image: "", expected: true},
+		{name: "Default axoflow image", image: axoflowOtelCollectorImageRef, expected: true},
+		{name: "Custom axoflow tag", image: axoflowOtelCollectorImageRepo + "/axoflow-otel-collector:dev", expected: true},
+		{name: "Upstream collector image", image: "otel/opentelemetry-collector-contrib:0.152.0", expected: false},
+		{name: "Unrelated custom image", image: "ghcr.io/example/custom-collector:1.0.0", expected: false},
+		{name: "Lookalike repo is not axoflow distribution", image: axoflowOtelCollectorImageRepo + "-fork:latest", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isAxoflowDistribution(tt.image))
+		})
+	}
+}

--- a/pkg/resources/otel_conf_gen/otel_conf_gen.go
+++ b/pkg/resources/otel_conf_gen/otel_conf_gen.go
@@ -41,6 +41,9 @@ type OtelColConfigInput struct {
 	MemoryLimiter v1alpha1.MemoryLimiter
 	Debug         bool
 	DryRunMode    bool
+
+	// IsAxoflowDistribution gates components only available in that distribution.
+	IsAxoflowDistribution bool
 }
 
 func (cfgInput *OtelColConfigInput) IsEmpty() bool {
@@ -75,7 +78,7 @@ func (cfgInput *OtelColConfigInput) generateExporters(ctx context.Context) map[s
 	maps.Copy(exporters, exporter.GenerateMetricsExporters())
 	maps.Copy(exporters, exporter.GenerateOTLPGRPCExporters(ctx, cfgInput.ResourceRelations))
 	maps.Copy(exporters, exporter.GenerateOTLPHTTPExporters(ctx, cfgInput.ResourceRelations))
-	maps.Copy(exporters, exporter.GenerateFluentforwardExporters(ctx, cfgInput.ResourceRelations))
+	maps.Copy(exporters, exporter.GenerateFluentforwardExporters(ctx, cfgInput.ResourceRelations, cfgInput.IsAxoflowDistribution))
 	maps.Copy(exporters, exporter.GenerateFileExporter(ctx, cfgInput.ResourceRelations))
 	maps.Copy(exporters, exporter.GenerateElasticsearchExporters(ctx, cfgInput.ResourceRelations))
 	maps.Copy(exporters, exporter.GenerateAWSS3Exporters(ctx, cfgInput.ResourceRelations))
@@ -177,7 +180,9 @@ func (cfgInput *OtelColConfigInput) generateConnectors() map[string]any {
 
 	if !cfgInput.DryRunMode {
 		maps.Copy(connectors, connector.GenerateCountConnectors())
-		maps.Copy(connectors, connector.GenerateBytesConnectors())
+		if cfgInput.IsAxoflowDistribution {
+			maps.Copy(connectors, connector.GenerateBytesConnectors())
+		}
 	}
 
 	for _, tenant := range cfgInput.Tenants {
@@ -216,7 +221,7 @@ func (cfgInput *OtelColConfigInput) generateNamedPipelines() map[string]*otelv1b
 	}
 
 	if !cfgInput.DryRunMode {
-		maps.Copy(namedPipelines, pipeline.GenerateMetricsPipelines())
+		maps.Copy(namedPipelines, pipeline.GenerateMetricsPipelines(cfgInput.IsAxoflowDistribution))
 	}
 
 	for _, tenant := range tenants {
@@ -261,7 +266,10 @@ func (cfgInput *OtelColConfigInput) generateNamedPipelines() map[string]*otelv1b
 						}
 						// GetExporterNameForOutput returns a non-empty name for any supported exporter.
 						if exporterName := components.GetExporterNameForOutput(output.Output); exporterName != "" {
-							exporters = append(exporters, exporterName, outputCountConnectorName, outputBytesConnectorName)
+							exporters = append(exporters, exporterName, outputCountConnectorName)
+							if cfgInput.IsAxoflowDistribution {
+								exporters = append(exporters, outputBytesConnectorName)
+							}
 						}
 					}
 

--- a/pkg/resources/otel_conf_gen/otel_conf_gen_test.go
+++ b/pkg/resources/otel_conf_gen/otel_conf_gen_test.go
@@ -104,6 +104,7 @@ func TestOtelColConfComplex(t *testing.T) {
 		},
 	}
 	inputCfg := OtelColConfigInput{
+		IsAxoflowDistribution: true,
 		ResourceRelations: components.ResourceRelations{
 			Subscriptions: subscriptions,
 			Tenants: []v1alpha1.Tenant{
@@ -464,7 +465,8 @@ func TestOtelColConfigInput_generateNamedPipelines(t *testing.T) {
 		{
 			name: "Single tenant with no subscriptions",
 			cfgInput: OtelColConfigInput{
-				DryRunMode: false,
+				DryRunMode:            false,
+				IsAxoflowDistribution: true,
 				ResourceRelations: components.ResourceRelations{
 					Bridges:               nil,
 					OutputsWithSecretData: nil,
@@ -509,8 +511,52 @@ func TestOtelColConfigInput_generateNamedPipelines(t *testing.T) {
 			},
 		},
 		{
+			name: "Non-axoflow distribution omits the bytes pipeline",
+			cfgInput: OtelColConfigInput{
+				DryRunMode:            false,
+				IsAxoflowDistribution: false,
+				ResourceRelations: components.ResourceRelations{
+					Bridges:               nil,
+					OutputsWithSecretData: nil,
+					TenantSubscriptionMap: map[string][]v1alpha1.NamespacedName{
+						"tenant1": {
+							{
+								Namespace: "ns1",
+								Name:      "sub1",
+							},
+						},
+					},
+					SubscriptionOutputMap: map[v1alpha1.NamespacedName][]v1alpha1.NamespacedName{
+						{
+							Namespace: "ns1",
+							Name:      "sub1",
+						}: {},
+					},
+				},
+			},
+			expectedPipelines: map[string]*otelv1beta1.Pipeline{
+				"logs/tenant_tenant1": pipeline.GenerateRootPipeline([]v1alpha1.Tenant{}, "tenant1", false),
+				"logs/tenant_tenant1_subscription_ns1_sub1": pipeline.GeneratePipeline(
+					[]string{"routing/tenant_tenant1_subscriptions"},
+					[]string{"attributes/subscription_sub1"},
+					[]string{"routing/subscription_ns1_sub1_outputs"},
+				),
+				"metrics/output": pipeline.GeneratePipeline(
+					[]string{"count/output_metrics"},
+					[]string{"deltatocumulative", "attributes/metricattributes"},
+					[]string{"prometheus/message_metrics_exporter"},
+				),
+				"metrics/tenant": pipeline.GeneratePipeline(
+					[]string{"count/tenant_metrics"},
+					[]string{"deltatocumulative", "attributes/metricattributes"},
+					[]string{"prometheus/message_metrics_exporter"},
+				),
+			},
+		},
+		{
 			name: "Three tenants two bridges",
 			cfgInput: OtelColConfigInput{
+				IsAxoflowDistribution: true,
 				ResourceRelations: components.ResourceRelations{
 					Tenants: []v1alpha1.Tenant{
 						{

--- a/pkg/resources/otel_conf_gen/pipeline/components/exporter/fluent_forward_exporter.go
+++ b/pkg/resources/otel_conf_gen/pipeline/components/exporter/fluent_forward_exporter.go
@@ -45,7 +45,7 @@ type FluentForwardWrapper struct {
 	Kubernetes  *v1alpha1.KubernetesMetadata `json:"kubernetes_metadata,omitempty"`
 }
 
-func (w *FluentForwardWrapper) mapToFluentForwardWrapper(userConfig *v1alpha1.Fluentforward) {
+func (w *FluentForwardWrapper) mapToFluentForwardWrapper(userConfig *v1alpha1.Fluentforward, isAxoflowDistribution bool) {
 	w.QueueConfig = &queueWrapper{}
 	w.RetryConfig = &backOffWrapper{}
 	w.QueueConfig.setDefaultQueueSettings(userConfig.QueueConfig)
@@ -63,20 +63,20 @@ func (w *FluentForwardWrapper) mapToFluentForwardWrapper(userConfig *v1alpha1.Fl
 	if userConfig.DefaultLabelsEnabled != nil {
 		w.DefaultLabelsEnabled = userConfig.DefaultLabelsEnabled
 	}
-	if userConfig.Kubernetes != nil {
+	if isAxoflowDistribution && userConfig.Kubernetes != nil {
 		w.Kubernetes = userConfig.Kubernetes
 	}
 	w.TCPClientSettings = userConfig.TCPClientSettings
 }
 
-func GenerateFluentforwardExporters(ctx context.Context, resourceRelations components.ResourceRelations) map[string]any {
+func GenerateFluentforwardExporters(ctx context.Context, resourceRelations components.ResourceRelations, isAxoflowDistribution bool) map[string]any {
 	logger := log.FromContext(ctx)
 
 	result := make(map[string]any)
 	for _, output := range resourceRelations.OutputsWithSecretData {
 		if output.Output.Spec.Fluentforward != nil {
 			internalConfig := FluentForwardWrapper{}
-			internalConfig.mapToFluentForwardWrapper(output.Output.Spec.Fluentforward)
+			internalConfig.mapToFluentForwardWrapper(output.Output.Spec.Fluentforward, isAxoflowDistribution)
 			tenant, err := resourceRelations.FindTenantForOutput(output.Output.NamespacedName())
 			if err != nil {
 				logger.Error(err, "failed to find tenant for output, skipping", "output", output.Output.NamespacedName().String())

--- a/pkg/resources/otel_conf_gen/pipeline/components/exporter/fluent_forward_exporter_test.go
+++ b/pkg/resources/otel_conf_gen/pipeline/components/exporter/fluent_forward_exporter_test.go
@@ -30,12 +30,14 @@ const testTenantName = "tenant1"
 
 func TestGenerateFluentforwardExporters(t *testing.T) {
 	tests := []struct {
-		name              string
-		resourceRelations components.ResourceRelations
-		expectedResult    map[string]any
+		name                  string
+		resourceRelations     components.ResourceRelations
+		isAxoflowDistribution bool
+		expectedResult        map[string]any
 	}{
 		{
-			name: "Valid config",
+			name:                  "Valid config",
+			isAxoflowDistribution: true,
 			resourceRelations: components.ResourceRelations{
 				Tenants: []v1alpha1.Tenant{
 					{
@@ -125,7 +127,8 @@ func TestGenerateFluentforwardExporters(t *testing.T) {
 			},
 		},
 		{
-			name: "All fields set, tls settings omitted",
+			name:                  "All fields set, tls settings omitted",
+			isAxoflowDistribution: true,
 			resourceRelations: components.ResourceRelations{
 				Tenants: []v1alpha1.Tenant{
 					{
@@ -233,11 +236,78 @@ func TestGenerateFluentforwardExporters(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                  "kubernetes_metadata dropped for non-axoflow distribution",
+			isAxoflowDistribution: false,
+			resourceRelations: components.ResourceRelations{
+				Tenants: []v1alpha1.Tenant{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: testTenantName,
+						},
+					},
+				},
+				OutputsWithSecretData: []components.OutputWithSecretData{
+					{
+						Output: v1alpha1.Output{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "output3",
+								Namespace: "default",
+							},
+							Spec: v1alpha1.OutputSpec{
+								Fluentforward: &v1alpha1.Fluentforward{
+									TCPClientSettings: v1alpha1.TCPClientSettings{
+										Endpoint: &v1alpha1.Endpoint{
+											TCPAddr: new("http://example.com"),
+										},
+									},
+									Kubernetes: &v1alpha1.KubernetesMetadata{Key: "key", IncludePodLabels: true},
+								},
+							},
+						},
+					},
+				},
+				TenantSubscriptionMap: map[string][]v1alpha1.NamespacedName{
+					testTenantName: {
+						{
+							Name:      "sub1",
+							Namespace: "default",
+						},
+					},
+				},
+				SubscriptionOutputMap: map[v1alpha1.NamespacedName][]v1alpha1.NamespacedName{
+					{
+						Name:      "sub1",
+						Namespace: "default",
+					}: {
+						{
+							Name:      "output3",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			expectedResult: map[string]any{
+				"fluentforwardexporter/default_output3": map[string]any{
+					"endpoint": map[string]any{
+						"tcp_addr": "http://example.com",
+					},
+					"sending_queue": map[string]any{
+						"enabled":    true,
+						"queue_size": float64(1000),
+					},
+					"retry_on_failure": map[string]any{
+						"enabled":          true,
+						"max_elapsed_time": "0s",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expectedResult, GenerateFluentforwardExporters(context.TODO(), tt.resourceRelations))
+			assert.Equal(t, tt.expectedResult, GenerateFluentforwardExporters(context.TODO(), tt.resourceRelations, tt.isAxoflowDistribution))
 		})
 	}
 }

--- a/pkg/resources/otel_conf_gen/pipeline/pipeline.go
+++ b/pkg/resources/otel_conf_gen/pipeline/pipeline.go
@@ -57,7 +57,7 @@ func GenerateRootPipeline(tenants []v1alpha1.Tenant, tenantName string, dryRunMo
 	return GeneratePipeline([]string{receiverName}, []string{"k8sattributes", fmt.Sprintf("attributes/tenant_%s", tenantName), "filter/exclude"}, []string{exporterName, tenantCountConnectorName})
 }
 
-func GenerateMetricsPipelines() map[string]*otelv1beta1.Pipeline {
+func GenerateMetricsPipelines(includeOutputBytes bool) map[string]*otelv1beta1.Pipeline {
 	metricsPipelines := make(map[string]*otelv1beta1.Pipeline)
 	metricsPipelines["metrics/tenant"] = &otelv1beta1.Pipeline{
 		Receivers:  []string{"count/tenant_metrics"},
@@ -70,10 +70,13 @@ func GenerateMetricsPipelines() map[string]*otelv1beta1.Pipeline {
 		Exporters:  []string{exporter.DefaultPrometheusExporterID},
 	}
 
-	metricsPipelines["metrics/output_bytes"] = &otelv1beta1.Pipeline{
-		Receivers:  []string{"bytes/exporter"},
-		Processors: []string{processor.DefaultDeltaToCumulativeProcessorID, "attributes/metricattributes"},
-		Exporters:  []string{exporter.DefaultPrometheusExporterID},
+	// The bytesconnector feeding this pipeline is only available in the axoflow-otel-collector distribution.
+	if includeOutputBytes {
+		metricsPipelines["metrics/output_bytes"] = &otelv1beta1.Pipeline{
+			Receivers:  []string{"bytes/exporter"},
+			Processors: []string{processor.DefaultDeltaToCumulativeProcessorID, "attributes/metricattributes"},
+			Exporters:  []string{exporter.DefaultPrometheusExporterID},
+		}
 	}
 
 	return metricsPipelines


### PR DESCRIPTION
Since we support custom images, it was possible to deploy a failing instance, this PR fixes that.